### PR TITLE
Hardcode Ruby scripts to use the Apple-provided version of MRI 1.8 since...

### DIFF
--- a/bin/gen_build
+++ b/bin/gen_build
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
 # == Synopsis
 #
 # gen_build: create build.ninja based on target files

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
 # == Synopsis
 #
 # gen_html: generates HTML file from markdown and optional template(s)

--- a/bin/process_plist
+++ b/bin/process_plist
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
 # == Synopsis
 #
 # process_plist: substitute ${VARIABLES} in text files


### PR DESCRIPTION
... rdoc/usage is missing in 1.9

Fixes issue #9 (https://github.com/textmate/textmate/issues/9)
