### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install using [MacPorts][]:
 
 You should install the [Ninja][NinjaBundle] and [CxxTest][] bundles. Both can be installed via _Preferences_ → _Bundles_.
 
-After this you can press ⌘B to build from within TextMate.
+After this you can press ⌘B to build from within TextMate. In case you haven't already you also need to set up the TextMate `PATH` variable in _Preferences_ → _Variables_ so TextMate can find the tools it needs; an example could would be `/usr/local/bin:/usr/bin:/bin`.
 
 The default target is `TextMate/run`. This will relaunch TextMate but when called from within TextMate, a dialog will appear before the current instance is killed. As there is full session restore, it is safe to relaunch even with unsaved changes.
 


### PR DESCRIPTION
In order to build from TextMate you also need
to set the PATH variable.

**Note** this patch was submitted and edited directly through Github so I apologise if it doesn't follow the rules for pull requests outlined in the README.
