### PR TITLE
Reuse existing window if it points to the same path as requested, i.e via `mate`.

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.h
+++ b/Frameworks/DocumentWindow/src/DocumentController.h
@@ -76,6 +76,7 @@ namespace bundles { struct item_t; typedef std::tr1::shared_ptr<item_t> item_ptr
 @property (nonatomic, readonly) NSString* untitledSavePath;
 
 + (DocumentController*)controllerForDocument:(document::document_ptr const&)aDocument;
++ (DocumentController*)controllerForPath:(std::string const&)aPath;
 + (DocumentController*)controllerForUUID:(oak::uuid_t const&)aUUID;
 
 - (id)init;


### PR DESCRIPTION
This is enhancement proposed at:

http://lists.macromates.com/textmate/2012-August/035164.html

"(...) make `mate <dir>` to popup the project/dir if it is already open and refrain from creating two windows with same folder open."
