### PR TITLE
Check for boost in $CPATH along with the hardcoded paths

### DIFF
--- a/configure
+++ b/configure
@@ -47,7 +47,7 @@ fi
 # = Check if boost is installed =
 # ===============================
 
-for dir in "${boostdir:-/usr/include/boost}" /{opt,usr}/local/include/boost; do
+for dir in "${boostdir:-/usr/include/boost}" /{opt,usr}/local/include/boost ${CPATH//:/ }; do
 	if [[ ! -L "${builddir}/include/boost" && -d "${dir}" ]]; then
 		mkdir -p "${builddir}/include" && ln -fs "${dir}" "${builddir}/include/boost"
 	fi


### PR DESCRIPTION
This way boost can be installed anywhere as long as the C compiler can find it.
