### PR TITLE
Fix clang searching to search Homebrew and MacPorts before defaulting to Xcode/Apple version

### DIFF
--- a/configure
+++ b/configure
@@ -24,21 +24,27 @@ rev=$(( $(curl -sf "${rest_api}/releases/nightly/revision")+1 )) || \
 		rev=$(git log --oneline master | wc -l)
 	fi
 
-# ===============================================
-# = Find clang via xcrun, MacPorts, or Homebrew =
-# ===============================================
-
-if which -s xcrun; then
-	: ${CC:=$(xcrun -find clang)}
-	: ${CXX:=$(xcrun -find clang++)}
-fi
+# ========================================================================
+# = Find clang via MacPorts, Homebrew or Xcode CLI Tools (in that order) =
+# ========================================================================
 
 for cc in /{opt,usr}/local/bin/clang /usr/bin/clang; do
-	if [[ ! -x "$CC" || ! -x "$CXX" ]]; then
+	if [[ -x "${cc}" && -x "${cc}++" ]]; then
 		CC="${cc}"
 		CXX="${cc}++"
+		break
 	fi
 done
+
+# =====================================
+# = Find clang via Xcode if necessary =
+# =====================================
+if [[ "${CC}" = "" || "${CXX}" = "" ]]; then
+  if which -s xcrun; then
+	  CC=$(xcrun -find clang)}
+	  CXX=$(xcrun -find clang++)}
+  fi
+fi
 
 test -x "$CC" || error "*** clang not installed."
 "$CC" &>/dev/null -x objective-c -include Foundation/Foundation.h -c -o /tmp/dummy - <<< 'int main () { id str = @("str"); return 0; }' || error "$CC is too old to build this project."


### PR DESCRIPTION
When fixing Issue 39 (a94ad3cc4c6c755c0740b2e6b0bf36bad59e5454), it seems the new code actually defaults to whatever xcrun finds which is not exactly correct.  Right now, I have the latest version of clang installed via Homebrew and the current configure will find and attempt to use clang that is located at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin instead of the clang in /usr/local/bin.  We want to explicitly search /opt/local/bin (MacPorts) and /usr/local/bin (Homebrew) prior to defaulting to Xcode.  This pull request addresses the situation and correctly searches in the following order:
- MacPorts: /opt/local/bin
- Homebrew: /usr/local/bin
- Xcode Command Line Tools: /usr/bin
- Xcode: Whatever xcrun provides, which as of Xcode 4.4.1 would be /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin and anything before would be /Developer/usr/bin
