### PR TITLE
find homebrew clang before xcode installed clang 

### DIFF
--- a/configure
+++ b/configure
@@ -33,7 +33,7 @@ if which -s xcrun; then
 	: ${CXX:=$(xcrun -find clang++)}
 fi
 
-for cc in /{opt,usr}/local/bin/clang /usr/bin/clang; do
+for cc in /usr/bin/clang /{opt,usr}/local/bin/clang ; do
 	if [[ ! -x "$CC" || ! -x "$CXX" ]]; then
 		CC="${cc}"
 		CXX="${cc}++"


### PR DESCRIPTION
this will find homebrew installed clang before xcode's /usr/bin/clang 
which, on SnowLeopard, is too old. other issues with snowleopard configure remain, 
