### PR TITLE
Custom drawing of key equivalents and tab triggers in the bundle menu

### DIFF
--- a/Frameworks/BundleMenu/src/BundleMenuDelegate.mm
+++ b/Frameworks/BundleMenu/src/BundleMenuDelegate.mm
@@ -2,6 +2,7 @@
 #import <OakAppKit/NSMenu Additions.h>
 #import <OakAppKit/NSMenuItem Additions.h>
 #import <OakFoundation/NSString Additions.h>
+#import <OakAppKit/OakBundleItemMenuItem.h>
 #import <oak/debug.h>
 
 OAK_DEBUG_VAR(BundleMenu);
@@ -33,6 +34,9 @@ OAK_DEBUG_VAR(BundleMenu);
 	D(DBF_BundleMenu, bug("\n"););
 	[aMenu removeAllItems];
 	[subdelegates removeAllObjects];
+	
+	OakBundleItemMenuItemAlignment alignmentData;
+	NSMutableArray* menuItems = [NSMutableArray array];
 
 	citerate(item, umbrellaItem->menu())
 	{
@@ -56,14 +60,18 @@ OAK_DEBUG_VAR(BundleMenu);
 
 			default:
 			{
-				NSMenuItem* menuItem = [aMenu addItemWithTitle:[NSString stringWithCxxString:(*item)->name()] action:@selector(doBundleItem:) keyEquivalent:@""];
-				[menuItem setKeyEquivalentCxxString:(*item)->value_for_field(bundles::kFieldKeyEquivalent)];
-				[menuItem setTabTriggerCxxString:(*item)->value_for_field(bundles::kFieldTabTrigger)];
+				OakBundleItemMenuItem* menuItem = [OakBundleItemMenuItem menuItemWithBundleItem:*item alignmentData:alignmentData];
 				[menuItem setRepresentedObject:[NSString stringWithCxxString:(*item)->uuid()]];
+				[aMenu addItem:menuItem];
+				
+				[menuItems addObject:menuItem];
 			}
 			break;
 		}
 	}
+	
+	for(OakBundleItemMenuItem* menuItem in menuItems)
+		[menuItem updateAlignment:alignmentData];
 }
 
 - (void)menuWillOpen:(NSMenu*)aMenu

--- a/Frameworks/OakAppKit/src/OakBundleItemMenuItem.h
+++ b/Frameworks/OakAppKit/src/OakBundleItemMenuItem.h
@@ -1,0 +1,16 @@
+#import <bundles/bundles.h>
+
+struct PUBLIC OakBundleItemMenuItemAlignment
+{
+	OakBundleItemMenuItemAlignment () : maxAlignmentWidth(0), maxRightWidth(0) {}
+	CGFloat maxAlignmentWidth;
+	CGFloat maxRightWidth;
+};
+
+@interface OakBundleItemMenuItem : NSMenuItem
+{
+	BOOL hasRightPart;
+}
++ (OakBundleItemMenuItem*)menuItemWithBundleItem:(bundles::item_ptr const&)bundleItem alignmentData:(OakBundleItemMenuItemAlignment&)alignment;
+- (void)updateAlignment:(OakBundleItemMenuItemAlignment&)alignment;
+@end

--- a/Frameworks/OakAppKit/src/OakBundleItemMenuItem.mm
+++ b/Frameworks/OakAppKit/src/OakBundleItemMenuItem.mm
@@ -1,0 +1,105 @@
+#import "OakBundleItemMenuItem.h"
+#import "NSColor Additions.h"
+#import <OakFoundation/NSString Additions.h>
+#import <ns/ns.h>
+
+@interface OakBundleItemMenuItem ()
+- (OakBundleItemMenuItem*)initWithBundleItem:(bundles::item_ptr const&)bundleItem alignmentData:(OakBundleItemMenuItemAlignment&)alignment;
+- (void)setAttributedTitleWithTitle:(NSAttributedString*)itemTitle equivLeft:(NSAttributedString*)equivLeft equivRight:(NSAttributedString*)equivRight alignmentData:(OakBundleItemMenuItemAlignment&)alignment;
+@end
+
+@implementation OakBundleItemMenuItem
++ (OakBundleItemMenuItem*)menuItemWithBundleItem:(bundles::item_ptr const&)bundleItem alignmentData:(OakBundleItemMenuItemAlignment&)alignment
+{
+	return [[[self alloc] initWithBundleItem:bundleItem alignmentData:alignment] autorelease];
+}
+
+- (OakBundleItemMenuItem*)initWithBundleItem:(bundles::item_ptr const&)bundleItem alignmentData:(OakBundleItemMenuItemAlignment&)alignment
+{
+	if ((self = [super init]))
+	{
+		NSDictionary* fontAttrs = @{ NSFontAttributeName : [NSFont menuFontOfSize:14] /* passing 0 should return the default size, but it doesn’t */ };
+		NSDictionary* smallFontAttrs = @{ NSFontAttributeName : [NSFont menuFontOfSize:11] };
+		NSAttributedString* title = [[NSAttributedString alloc] initWithString:[NSString stringWithCxxString:bundleItem->name()] attributes:fontAttrs];
+		NSAttributedString* equivLeft = nil;
+		NSAttributedString* equivRight = nil;
+	
+		std::string const tabTrigger(bundleItem->value_for_field(bundles::kFieldTabTrigger));
+		std::string const keyEquiv(bundleItem->value_for_field(bundles::kFieldKeyEquivalent));
+	
+		if(tabTrigger != NULL_STR)
+		{
+			equivLeft = [[[NSAttributedString alloc] initWithString:[NSString stringWithCxxString:(" "+tabTrigger+"\u21E5 ")] attributes:smallFontAttrs] autorelease];
+		}
+		else if(keyEquiv != NULL_STR)
+		{
+			size_t keyStart = 0;
+			std::string const glyphStr(ns::glyphs_for_event_string(keyEquiv, &keyStart));
+		
+			equivLeft = [[[NSAttributedString alloc] initWithString:[NSString stringWithCxxString:glyphStr.substr(0, keyStart)] attributes:fontAttrs] autorelease];
+			equivRight = [[[NSAttributedString alloc] initWithString:[NSString stringWithCxxString:glyphStr.substr(keyStart)] attributes:fontAttrs] autorelease];
+		}
+	
+		[self setAttributedTitleWithTitle:title equivLeft:equivLeft equivRight:equivRight alignmentData:alignment];
+	}
+	
+	return self;
+}
+
+- (void)setAttributedTitleWithTitle:(NSAttributedString*)itemTitle equivLeft:(NSAttributedString*)equivLeft equivRight:(NSAttributedString*)equivRight alignmentData:(OakBundleItemMenuItemAlignment&)alignment
+{
+	NSMutableAttributedString* title = [[[NSMutableAttributedString alloc] initWithAttributedString:itemTitle] autorelease];
+	[title beginEditing];
+	
+	CGFloat alignmentWidth = [itemTitle size].width;
+	CGFloat rightWidth = [equivRight size].width;
+	CGFloat leftWidth = [equivLeft size].width;
+	
+	if(equivLeft)
+	{
+		[title appendAttributedString:[[[NSAttributedString alloc] initWithString:@"\t"] autorelease]];
+		[title appendAttributedString:equivLeft];
+		
+		alignmentWidth += leftWidth + 20;
+		
+		if(equivRight)
+		{
+			[title appendAttributedString:[[[NSAttributedString alloc] initWithString:@"\t"] autorelease]];
+			[title appendAttributedString:equivRight];
+			hasRightPart = YES;
+		}
+	}
+	
+	if(alignmentWidth > alignment.maxAlignmentWidth)
+		alignment.maxAlignmentWidth = alignmentWidth;
+	
+	if(rightWidth > alignment.maxRightWidth)
+		alignment.maxRightWidth = rightWidth;
+
+	[title endEditing];
+	[self setAttributedTitle:title];
+}
+
+- (void)updateAlignment:(OakBundleItemMenuItemAlignment&)alignment
+{
+	NSMutableParagraphStyle* pStyle = [[NSMutableParagraphStyle new] autorelease];
+	if(hasRightPart)
+	{
+		[pStyle setTabStops:@[
+			[[[NSTextTab alloc] initWithType:NSRightTabStopType location:alignment.maxAlignmentWidth] autorelease],
+			[[[NSTextTab alloc] initWithType:NSLeftTabStopType location:alignment.maxAlignmentWidth + 0.01] autorelease]
+		]];
+	}
+	else
+	{
+		[pStyle setTabStops:@[
+			[[[NSTextTab alloc] initWithType:NSRightTabStopType location:alignment.maxAlignmentWidth + alignment.maxRightWidth] autorelease]
+		]];
+	}
+	
+	NSMutableAttributedString* title = [[self attributedTitle] mutableCopy];
+	[title addAttribute:NSParagraphStyleAttributeName value:pStyle range:NSMakeRange(0, [title length])];
+	
+	[self setAttributedTitle:title];
+}
+@end

--- a/Frameworks/OakAppKit/target
+++ b/Frameworks/OakAppKit/target
@@ -1,6 +1,6 @@
 SOURCES      = src/*.{cc,mm}
 CP_Resources = resources/* gfx/**/*.{png,tiff,icns} icons/*
 TEST_SOURCES = tests/*.{cc,mm}
-LINK        += text ns io OakFoundation regexp scm
+LINK        += text ns io OakFoundation regexp scm bundles
 EXPORT       = src/*.h
 FRAMEWORKS   = Carbon Cocoa AudioToolbox Quartz


### PR DESCRIPTION
Yet to be done:
- render rounded rect background for tab triggers (this may be very hard while still using `NSAttributedString`)
- fix e.g. spacebar shows up as "␣" instead of "Space" like it normally does in menus
