### PR TITLE
Set a blank SDK path if the 10.7 SDK isn't found.

### DIFF
--- a/configure
+++ b/configure
@@ -69,7 +69,12 @@ sdk="/Developer/SDKs/${sdk:-MacOSX10.7}.sdk"
 if which -s xcode-select; then
 	xcodedir=$(xcode-select -print-path)
 	if ! [[ -e "$sdk" ]]; then
-		sdk="$xcodedir/Platforms/MacOSX.platform$sdk"
+		if [[ -d $xcodedir/Platforms/MacOSX.platform$sdk ]]; then
+			sdk="$xcodedir/Platforms/MacOSX.platform$sdk"
+		else
+			sdk=""
+			echo 2>&1 "WARNING: Building without platform-specific SDK."
+		fi
 	fi
 fi
 


### PR DESCRIPTION
This allows the project to build with the system default framework/include/library paths.
