### PR TITLE
Double check if local (MacPorts, Brew) clang version is okay

### DIFF
--- a/configure
+++ b/configure
@@ -28,20 +28,28 @@ rev=$(( $(curl -sf "${rest_api}/releases/nightly/revision")+1 )) || \
 # = Find clang via xcrun, MacPorts, or Homebrew =
 # ===============================================
 
-if which -s xcrun; then
-	: ${CC:=$(xcrun -find clang)}
-	: ${CXX:=$(xcrun -find clang++)}
-fi
-
-for cc in /{opt,usr}/local/bin/clang /usr/bin/clang; do
-	if [[ ! -x "$CC" || ! -x "$CXX" ]]; then
-		CC="${cc}"
-		CXX="${cc}++"
+check_xcode_clang() {
+	if which -s xcrun; then
+		: ${CC:=$(xcrun -find clang)}
+		: ${CXX:=$(xcrun -find clang++)}
 	fi
-done
+}
+check_local_clang() {
+	for cc in /{opt,usr}/local/bin/clang /usr/bin/clang; do
+		if [[ ! -x "$CC" || ! -x "$CXX" ]]; then
+			CC="${cc}"
+			CXX="${cc}++"
+		fi
+	done
+}
+check_clang_caps() {
+	"$CC" &>/dev/null -x objective-c -include Foundation/Foundation.h -c -o /dev/null - <<< 'int main () { id str = @("str"); return 0; }'
+}
 
+check_xcode_clang
+check_local_clang
 test -x "$CC" || error "*** clang not installed."
-"$CC" &>/dev/null -x objective-c -include Foundation/Foundation.h -c -o /dev/null - <<< 'int main () { id str = @("str"); return 0; }' || error "$CC is too old to build this project."
+check_clang_caps || { clang=$CC; CC=; CXX=; check_local_clang; test -x "$CC" && check_clang_caps || error "$clang is too old to build this project."; }
 
 # ===============================
 # = Check if boost is installed =


### PR DESCRIPTION
Right when Xcode version (checked first) is too old, `configure` just prints out that _clang_ is too old and quits. 

This change makes `configure` check again, but this time only locally installed clang, just in case user has old Xcode but new _clang_ installed via _MacPorts_ or _Brew_.

Ouch... I think this is the last change for TM2 today :>
