### PR TITLE
Moved File Viewer Toolbar

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -1409,8 +1409,8 @@ static std::string file_chooser_glob (std::string const& path)
 			[layoutView addView:fileBrowser.view atEdge:(placeOnRight ? NSMaxXEdge : NSMinXEdge) ofView:documentView];
 			[layoutView setLocked:YES forView:fileBrowser.view];
 			if(placeOnRight)
-					[layoutView addResizeInfo:(OakResizeInfo){  11, 15, OakResizeInfo::kTopLeft,  OakResizeInfo::kWidth } forView:fileBrowser.view];
-			else	[layoutView addResizeInfo:(OakResizeInfo){ -11, 15, OakResizeInfo::kTopRight, OakResizeInfo::kWidth } forView:fileBrowser.view];
+					[layoutView addResizeInfo:(OakResizeInfo){  11, -15, OakResizeInfo::kBottomLeft,  OakResizeInfo::kWidth } forView:fileBrowser.view];
+			else	[layoutView addResizeInfo:(OakResizeInfo){ -11, -15, OakResizeInfo::kBottomRight, OakResizeInfo::kWidth } forView:fileBrowser.view];
 		}
 	}
 	document::schedule_session_backup();

--- a/Frameworks/OakFileBrowser/src/ui/OakFileBrowserView.mm
+++ b/Frameworks/OakFileBrowser/src/ui/OakFileBrowserView.mm
@@ -53,7 +53,7 @@ OAK_DEBUG_VAR(FileBrowser_View);
 	scrollView.documentView              = outlineView;
 
 	headerView             = [[[OakStatusBar alloc] initWithFrame:NSZeroRect] autorelease];
-	headerView.borderEdges = sb::border::bottom;
+	headerView.borderEdges = sb::border::top;
 	[self addSubview:headerView];
 
 	NSCell* cell       = [[OFBPathInfoCell new] autorelease];
@@ -92,8 +92,8 @@ OAK_DEBUG_VAR(FileBrowser_View);
 
 - (void)resizeSubviewsWithOldSize:(NSSize)oldSize
 {
-	headerView.frame                      = NSMakeRect(0, NSHeight(self.frame) - OakStatusBarHeight, NSWidth(self.frame), OakStatusBarHeight);
-	outlineView.enclosingScrollView.frame = NSMakeRect(0, 0, NSWidth(self.frame), NSHeight(self.frame) - NSHeight(headerView.frame));
+	headerView.frame                      = NSMakeRect(0, 0, NSWidth(self.frame), OakStatusBarHeight);
+	outlineView.enclosingScrollView.frame = NSMakeRect(0, OakStatusBarHeight, NSWidth(self.frame), NSHeight(self.frame) - NSHeight(headerView.frame));
 }
 
 - (BOOL)isOpaque


### PR DESCRIPTION
Moved the file viewer's toolbar to the bottom for esthetic reasons.
