### PR TITLE
Small speed up to theme style resolution

### DIFF
--- a/Frameworks/theme/src/theme.cc
+++ b/Frameworks/theme/src/theme.cc
@@ -7,6 +7,13 @@ static void get_set_key_path(plist::dictionary_t const& plist, std::string const
 	plist::get_key_path(plist, setting, temp_str);
 	color = read_color(temp_str);
 }
+static CGFloat read_font_size (std::string const& str_font_size );
+static void get_set_key_path(plist::dictionary_t const& plist, std::string const& setting, CGFloat& font_size) {
+	std::string temp_str = NULL_STR;
+	plist::get_key_path(plist, setting, temp_str);
+	font_size = read_font_size(temp_str);
+}
+
 theme_t::decomposed_style_t theme_t::parse_styles (plist::dictionary_t const& plist)
 {
 	decomposed_style_t res;
@@ -16,7 +23,7 @@ theme_t::decomposed_style_t theme_t::parse_styles (plist::dictionary_t const& pl
 		res.scope_selector = scopeSelector;
 
 	plist::get_key_path(plist, "settings.fontName",   res.font_name);
-	plist::get_key_path(plist, "settings.fontSize",   res.font_size);
+	get_set_key_path(plist, "settings.fontSize",   res.absolute_font_size);
 	get_set_key_path(plist, "settings.foreground", res.foreground);
 	get_set_key_path(plist, "settings.background", res.background);
 	get_set_key_path(plist, "settings.caret",      res.caret);
@@ -60,8 +67,13 @@ std::vector<theme_t::decomposed_style_t> theme_t::global_styles (scope::context_
 	static struct { std::string name; std::string decomposed_style_t::*field; } const stringKeys[] =
 	{
 		{ "fontName",   &decomposed_style_t::font_name  },
-		{ "fontSize",   &decomposed_style_t::font_size  },
 	};
+	
+	static struct { std::string name; CGFloat decomposed_style_t::*field; } const doubleKeys[] =
+	{
+		{ "fontSize",   &decomposed_style_t::absolute_font_size  },
+	};
+	
 
 	static struct { std::string name; bool_t decomposed_style_t::*field; } const booleanKeys[] =
 	{
@@ -92,6 +104,17 @@ std::vector<theme_t::decomposed_style_t> theme_t::global_styles (scope::context_
 		{
 			res.push_back(decomposed_style_t(item->scope_selector()));
 			res.back().*(stringKeys[i].field) = plist::get<std::string>(value);
+		}
+	}
+
+	for(size_t i = 0; i < sizeofA(doubleKeys); ++i)
+	{
+		bundles::item_ptr item;
+		plist::any_t const& value = bundles::value_for_setting(doubleKeys[i].name, scope, &item);
+		if(item)
+		{
+			res.push_back(decomposed_style_t(item->scope_selector()));
+			res.back().*(doubleKeys[i].field) = read_font_size(plist::get<std::string>(value));
 		}
 	}
 
@@ -152,6 +175,7 @@ void theme_t::setup_styles ()
 			}
 		}
 	}
+
 }
 
 oak::uuid_t const& theme_t::uuid () const
@@ -167,25 +191,25 @@ styles_t const& theme_t::styles_for_scope (scope::context_t const& scope, std::s
 	std::map<key_t, styles_t>::iterator styles = _cache.find(key_t(scope, fontName, fontSize));
 	if(styles == _cache.end())
 	{
+
 		std::multimap<double, decomposed_style_t> ordering;
 		citerate(it, global_styles(scope))
 		{
-			double rank = 0;
-			if(it->scope_selector.does_match(scope, &rank))
-				ordering.insert(std::make_pair(rank, *it));
+		        double rank = 0;
+		        if(it->scope_selector.does_match(scope, &rank))
+		                ordering.insert(std::make_pair(rank, *it));
 		}
-
+		
 		iterate(it, _styles)
 		{
-			double rank = 0;
-			if(it->scope_selector.does_match(scope, &rank))
-				ordering.insert(std::make_pair(rank, *it));
+		        double rank = 0;
+		        if(it->scope_selector.does_match(scope, &rank))
+		                ordering.insert(std::make_pair(rank, *it));
 		}
 
 		decomposed_style_t base(scope::selector_t(), fontName, fontSize);
 		iterate(it, ordering)
 			base += it->second;
-
 		CTFontPtr font(CTFontCreateWithName(cf::wrap(base.font_name), round(base.absolute_font_size), NULL), CFRelease);
 		if(CTFontSymbolicTraits traits = (base.bold == bool_true ? kCTFontBoldTrait : 0) + (base.italic == bool_true ? kCTFontItalicTrait : 0))
 		{
@@ -197,9 +221,10 @@ styles_t const& theme_t::styles_for_scope (scope::context_t const& scope, std::s
 		cf::color_t background = base.background.is_blank() ? cf::color_t("#FFFFFF"  ) : base.background;
 		cf::color_t selection  = base.selection.is_blank()  ? cf::color_t("#4D97FF54") : base.selection;
 		cf::color_t caret      = base.caret.is_blank()      ? cf::color_t("#000000"  ) : base.caret;
-//		base.invisibles = base.invisibles == NULL_STR ? "#BFBFBF"   : base.invisibles;
+	//	base.invisibles = base.invisibles == NULL_STR ? "#BFBFBF"   : base.invisibles;
 
 		styles_t res(foreground, background, selection, caret, font, base.underlined == bool_true, base.misspelled == bool_true);
+		
 		styles = _cache.insert(std::make_pair(key_t(scope, fontName, fontSize), res)).first;
 	}
 	return styles->second;
@@ -259,6 +284,14 @@ static void alpha_blend (theme_t::color_info_t& lhs, theme_t::color_info_t const
 	}
 }
 
+static void calculate_font_size (CGFloat& absolute_font_size, CGFloat font_size ) 
+{
+	if(font_size > 0)
+		absolute_font_size = font_size;
+	else 
+		absolute_font_size = absolute_font_size * fabs(font_size);	
+}
+
 static double my_strtod (char const* str, char const** last) // problem with strtod() is that it uses LC_NUMERIC for point separator.
 {
 	double res = atof(str);
@@ -271,13 +304,13 @@ static double my_strtod (char const* str, char const** last) // problem with str
 	return res;
 }
 
-theme_t::decomposed_style_t& theme_t::decomposed_style_t::operator+= (theme_t::decomposed_style_t const& rhs)
+static CGFloat read_font_size (std::string const& str_font_size ) 
 {
-	font_name = rhs.font_name == NULL_STR ? font_name : rhs.font_name;
-
-	if(rhs.font_size != NULL_STR)
+	// Treat positive values as absolute font
+	// and negative as relative, that way we don't have to use a bool as a flag :)
+	if(str_font_size != NULL_STR)
 	{
-		char const* first = rhs.font_size.c_str();
+		char const* first = str_font_size.c_str();
 		char const* last;
 		double size = my_strtod(first, &last);
 		if(first != last)
@@ -286,19 +319,28 @@ theme_t::decomposed_style_t& theme_t::decomposed_style_t::operator+= (theme_t::d
 				++last;
 
 			if(strcmp(last, "pt") == 0 || *last == '\0')
-				absolute_font_size = size;
+				return size;
 			else if(strcmp(last, "em") == 0)
-				absolute_font_size = absolute_font_size * size;
+				return -size;
 			else if(strcmp(last, "%") == 0)
-				absolute_font_size = absolute_font_size * size / 100;
+				 return -size / 100;
 			else
-				fprintf(stderr, "*** unsupported font size unit: %s (%s)\n", last, rhs.font_size.c_str());
+				fprintf(stderr, "*** unsupported font size unit: %s (%s)\n", last, str_font_size.c_str());
 		}
 		else
 		{
-			fprintf(stderr, "*** unsupported font size format: %s\n", rhs.font_size.c_str());
+			fprintf(stderr, "*** unsupported font size format: %s\n", str_font_size.c_str());
 		}
 	}
+	return -1.0;
+}
+
+
+theme_t::decomposed_style_t& theme_t::decomposed_style_t::operator+= (theme_t::decomposed_style_t const& rhs)
+{
+	font_name = rhs.font_name == NULL_STR ? font_name : rhs.font_name;
+
+	calculate_font_size(absolute_font_size, rhs.absolute_font_size);
 
 	alpha_blend(foreground, rhs.foreground);
 	alpha_blend(background, rhs.background);
@@ -328,4 +370,8 @@ theme_ptr parse_theme (bundles::item_ptr const& themeItem)
 	if(theme == Cache.end())
 		theme = Cache.insert(std::make_pair(uuid, theme_ptr(new theme_t(themeItem)))).first;
 	return theme->second;
+}
+
+std::string to_s (styles_t const& s) {
+	return "style! fg:" + to_s(s._foreground) + " bg:" + to_s(s._background) + " cr:"+to_s(s._caret) + " sel:"+to_s(s._selection);
 }

--- a/Frameworks/theme/src/theme.h
+++ b/Frameworks/theme/src/theme.h
@@ -18,7 +18,7 @@ struct PUBLIC styles_t
 	CTFontRef font () const        { return _font.get(); }
 	bool underlined () const       { return _underlined; }
 	bool misspelled () const       { return _misspelled; }
-
+	friend std::string to_s (styles_t const& c);
 private:
 	cf::color_t _foreground;
 	cf::color_t _background;
@@ -28,6 +28,7 @@ private:
 	bool _underlined;
 	bool _misspelled;
 };
+PUBLIC std::string to_s (styles_t const& c);
 
 struct PUBLIC theme_t
 {
@@ -47,21 +48,20 @@ struct PUBLIC theme_t
 			double alpha;
 			bool is_blank () const { return red < 0.0 ; }
 			bool is_opaque () const { return alpha == 1.0; };
-			operator cf::color_t () { 	return cf::color_t(text::format("#%02lX%02lX%02lX%02lX", lround(255 * red), lround(255 * green), lround(255 * blue), lround(255 * alpha)));
-}
+			operator cf::color_t () { return cf::color_t(text::format("#%02lX%02lX%02lX%02lX", lround(255 * red), lround(255 * green), lround(255 * blue), lround(255 * alpha))); }
 		};
 private:
 	enum bool_t { bool_true, bool_false, bool_unset };
 
 	struct decomposed_style_t
 	{
-		decomposed_style_t (scope::selector_t const& scopeSelector = scope::selector_t(), std::string const& fontName = NULL_STR, CGFloat fontSize = 0) : scope_selector(scopeSelector), font_name(fontName), font_size(NULL_STR), bold(bool_unset), italic(bool_unset), underlined(bool_unset), misspelled(bool_unset), absolute_font_size(fontSize) { }
+		decomposed_style_t (scope::selector_t const& scopeSelector = scope::selector_t(), std::string const& fontName = NULL_STR, CGFloat fontSize = 0) : scope_selector(scopeSelector), font_name(fontName), bold(bool_unset), italic(bool_unset), underlined(bool_unset), misspelled(bool_unset), absolute_font_size(fontSize) { }
+
 		decomposed_style_t& operator+= (decomposed_style_t const& rhs);
 
 		scope::selector_t scope_selector;
 
 		std::string font_name;
-		std::string font_size;
 		color_info_t foreground;
 		color_info_t background;
 		color_info_t caret;


### PR DESCRIPTION
By switching from std::string to doubles for color and size representation. We avoid having to convert back and forth when calculating the style
