### PR TITLE
Extend support for theming the gutter

### DIFF
--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -264,13 +264,12 @@ private:
 		[self setFont:textView.font]; // trigger update of gutter view’s line number font	
 		auto styles = [textView theme]->styles_for_scope(document->buffer().scope(0).left, NULL_STR, 0);
 		self.gutterDividerColor = [NSColor colorWithCGColor:styles.gutterDivider()] ?: [NSColor grayColor];
-		
+
 		gutterView.foregroundColor = [NSColor colorWithCGColor:styles.gutterForeground()];
 		gutterView.backgroundColor = [NSColor colorWithCGColor:styles.gutterBackground()];
 		gutterScrollView.backgroundColor = gutterView.backgroundColor;
-		NSColor* selColor = [NSColor colorWithCGColor:styles.selection()];
-		gutterView.selectionColor = [selColor colorWithAlphaComponent:[selColor alphaComponent] * 0.5];
-		
+		gutterView.selectionColor = [NSColor colorWithCGColor:styles.gutterSelectionBackground()];
+
 		[self setNeedsDisplay:YES];
 		[textView setNeedsDisplay:YES];
 		[gutterView setNeedsDisplay:YES];

--- a/Frameworks/theme/src/theme.cc
+++ b/Frameworks/theme/src/theme.cc
@@ -27,16 +27,17 @@ theme_t::decomposed_style_t theme_t::parse_styles (plist::dictionary_t const& pl
 	if(plist::get_key_path(plist, "scope", scopeSelector))
 		res.scope_selector = scopeSelector;
 
-	plist::get_key_path(plist, "settings.fontName",   res.font_name);
-	get_key_path(plist, "settings.fontSize",          res.font_size);
-	get_key_path(plist, "settings.foreground",        res.foreground);
-	get_key_path(plist, "settings.background",        res.background);
-	get_key_path(plist, "settings.gutterForeground",  res.gutterForeground);
-	get_key_path(plist, "settings.gutterBackground",  res.gutterBackground);
-	get_key_path(plist, "settings.gutterDivider",     res.gutterDivider);
-	get_key_path(plist, "settings.caret",             res.caret);
-	get_key_path(plist, "settings.selection",         res.selection);
-	get_key_path(plist, "settings.invisibles",        res.invisibles);
+	plist::get_key_path(plist, "settings.fontName",           res.font_name);
+	get_key_path(plist, "settings.fontSize",                  res.font_size);
+	get_key_path(plist, "settings.foreground",                res.foreground);
+	get_key_path(plist, "settings.background",                res.background);
+	get_key_path(plist, "settings.gutterForeground",          res.gutterForeground);
+	get_key_path(plist, "settings.gutterBackground",          res.gutterBackground);
+	get_key_path(plist, "settings.gutterDivider",             res.gutterDivider);
+	get_key_path(plist, "settings.gutterSelectionBackground", res.gutterSelectionBackground);
+	get_key_path(plist, "settings.caret",                     res.caret);
+	get_key_path(plist, "settings.selection",                 res.selection);
+	get_key_path(plist, "settings.invisibles",                res.invisibles);
 
 	bool flag;
 	res.misspelled = plist::get_key_path(plist, "settings.misspelled", flag) ? (flag ? bool_true : bool_false) : bool_unset;
@@ -206,15 +207,16 @@ styles_t const& theme_t::styles_for_scope (scope::context_t const& scope, std::s
 				font.reset(newFont, CFRelease);
 		}
 
-		cf::color_t foreground = base.foreground.is_blank()             ? cf::color_t("#000000"  ) : base.foreground;
-		cf::color_t background = base.background.is_blank()             ? cf::color_t("#FFFFFF"  ) : base.background;
-		cf::color_t gutterForeground = base.gutterForeground.is_blank() ? soften(foreground, 0.5 ) : base.gutterForeground;
-		cf::color_t gutterBackground = base.gutterBackground.is_blank() ? soften(background, 0.87) : base.gutterBackground;
-		cf::color_t gutterDivider = base.gutterDivider.is_blank()       ? soften(foreground, 0.4 ) : base.gutterDivider;
-		cf::color_t selection  = base.selection.is_blank()              ? cf::color_t("#4D97FF54") : base.selection;
-		cf::color_t caret      = base.caret.is_blank()                  ? cf::color_t("#000000"  ) : base.caret;
+		cf::color_t foreground = base.foreground.is_blank()                               ? cf::color_t("#000000"  ) : base.foreground;
+		cf::color_t background = base.background.is_blank()                               ? cf::color_t("#FFFFFF"  ) : base.background;
+		cf::color_t gutterForeground = base.gutterForeground.is_blank()                   ? soften(foreground, 0.5 ) : base.gutterForeground;
+		cf::color_t gutterBackground = base.gutterBackground.is_blank()                   ? soften(background, 0.87) : base.gutterBackground;
+		cf::color_t gutterDivider = base.gutterDivider.is_blank()                         ? soften(foreground, 0.4 ) : base.gutterDivider;
+		cf::color_t gutterSelectionBackground = base.gutterSelectionBackground.is_blank() ? soften(background, 0.95) : base.gutterSelectionBackground;
+		cf::color_t selection  = base.selection.is_blank()                                ? cf::color_t("#4D97FF54") : base.selection;
+		cf::color_t caret      = base.caret.is_blank()                                    ? cf::color_t("#000000"  ) : base.caret;
 
-		styles_t res(foreground, background, gutterForeground, gutterBackground, gutterDivider, selection, caret, font, base.underlined == bool_true, base.misspelled == bool_true);
+		styles_t res(foreground, background, gutterForeground, gutterBackground, gutterDivider, gutterSelectionBackground, selection, caret, font, base.underlined == bool_true, base.misspelled == bool_true);
 		styles = _cache.insert(std::make_pair(key_t(scope, fontName, fontSize), res)).first;
 	}
 	return styles->second;
@@ -319,14 +321,15 @@ theme_t::decomposed_style_t& theme_t::decomposed_style_t::operator+= (theme_t::d
 	font_name = rhs.font_name == NULL_STR ? font_name : rhs.font_name;
 	font_size = rhs.font_size > 0 ? rhs.font_size : font_size * fabs(rhs.font_size);
 
-	alpha_blend(foreground,       rhs.foreground);
-	alpha_blend(background,       rhs.background);
-	alpha_blend(gutterForeground, rhs.gutterForeground);
-	alpha_blend(gutterBackground, rhs.gutterBackground);
-	alpha_blend(gutterDivider,    rhs.gutterDivider);
-	alpha_blend(caret,            rhs.caret);
-	alpha_blend(selection,        rhs.selection);
-	alpha_blend(invisibles,       rhs.invisibles);
+	alpha_blend(foreground,                rhs.foreground);
+	alpha_blend(background,                rhs.background);
+	alpha_blend(gutterForeground,          rhs.gutterForeground);
+	alpha_blend(gutterBackground,          rhs.gutterBackground);
+	alpha_blend(gutterDivider,             rhs.gutterDivider);
+	alpha_blend(gutterSelectionBackground, rhs.gutterSelectionBackground);
+	alpha_blend(caret,                     rhs.caret);
+	alpha_blend(selection,                 rhs.selection);
+	alpha_blend(invisibles,                rhs.invisibles);
 
 	bold       = rhs.bold       == bool_unset ? bold       : rhs.bold;
 	italic     = rhs.italic     == bool_unset ? italic     : rhs.italic;

--- a/Frameworks/theme/src/theme.h
+++ b/Frameworks/theme/src/theme.h
@@ -9,18 +9,19 @@ typedef std::tr1::shared_ptr<struct __CTFont const> CTFontPtr;
 
 struct PUBLIC styles_t
 {
-	styles_t (cf::color_t const& foreground, cf::color_t const& background, cf::color_t const& gutterForeground, cf::color_t const& gutterBackground, cf::color_t const& gutterDivider, cf::color_t const& selection, cf::color_t const& caret, CTFontPtr font, bool underlined, bool misspelled) : _foreground(foreground), _background(background), _gutterForeground(gutterForeground), _gutterBackground(gutterBackground), _gutterDivider(gutterDivider), _selection(selection), _caret(caret), _font(font), _underlined(underlined), _misspelled(misspelled) { }
+	styles_t (cf::color_t const& foreground, cf::color_t const& background, cf::color_t const& gutterForeground, cf::color_t const& gutterBackground, cf::color_t const& gutterDivider, cf::color_t const& gutterSelectionBackground, cf::color_t const& selection, cf::color_t const& caret, CTFontPtr font, bool underlined, bool misspelled) : _foreground(foreground), _background(background), _gutterForeground(gutterForeground), _gutterBackground(gutterBackground), _gutterDivider(gutterDivider), _gutterSelectionBackground(gutterSelectionBackground), _selection(selection), _caret(caret), _font(font), _underlined(underlined), _misspelled(misspelled) { }
 
-	CGColorRef foreground () const       { return _foreground; }
-	CGColorRef background () const       { return _background; }
-	CGColorRef gutterForeground () const { return _gutterForeground; }
-	CGColorRef gutterBackground () const { return _gutterBackground; }
-	CGColorRef gutterDivider () const    { return _gutterDivider; }
-	CGColorRef caret () const            { return _caret; }
-	CGColorRef selection () const        { return _selection; }
-	CTFontRef font () const              { return _font.get(); }
-	bool underlined () const             { return _underlined; }
-	bool misspelled () const             { return _misspelled; }
+	CGColorRef foreground () const               { return _foreground; }
+	CGColorRef background () const               { return _background; }
+	CGColorRef gutterForeground () const         { return _gutterForeground; }
+	CGColorRef gutterBackground () const         { return _gutterBackground; }
+	CGColorRef gutterDivider () const            { return _gutterDivider; }
+	CGColorRef gutterSelectionBackground() const { return _gutterSelectionBackground; }
+	CGColorRef caret () const                    { return _caret; }
+	CGColorRef selection () const                { return _selection; }
+	CTFontRef font () const                      { return _font.get(); }
+	bool underlined () const                     { return _underlined; }
+	bool misspelled () const                     { return _misspelled; }
 
 private:
 	cf::color_t _foreground;
@@ -28,6 +29,7 @@ private:
 	cf::color_t _gutterForeground;
 	cf::color_t _gutterBackground;
 	cf::color_t _gutterDivider;
+	cf::color_t _gutterSelectionBackground;
 	cf::color_t _selection;
 	cf::color_t _caret;
 	CTFontPtr _font;
@@ -73,6 +75,7 @@ private:
 		color_info_t gutterForeground;
 		color_info_t gutterBackground;
 		color_info_t gutterDivider;
+		color_info_t gutterSelectionBackground;
 		color_info_t caret;
 		color_info_t selection;
 		color_info_t invisibles;


### PR DESCRIPTION
New theme setting: gutterSelectionBackground

Shadows the changes made for the initial gutter view theming.

Ideally would also add in gutterSelectionForeground colour to allow colour theming of the selected line numbers text too, but this seems to be a bit more complicated to implement (at the [GutterView drawRect] level), so leaving for now!

Note: this code also changes the default gutter selection color from the previous change.  It now defaults to "softened" version of the background colour, rather than the selection colour.
