### PR TITLE
Add scope attributes for Ant, CMake, Maven and Scons projects.

### DIFF
--- a/Frameworks/file/src/path_info.cc
+++ b/Frameworks/file/src/path_info.cc
@@ -41,14 +41,18 @@ namespace
 	{
 		static std::string const DefaultScopeAttributes =
 			"{ rules = ("
-			"	{ attribute = 'attr.scm.svn';       glob = '.svn';        group = 'scm';   },"
-			"	{ attribute = 'attr.scm.hg';        glob = '.hg';         group = 'scm';   },"
-			"	{ attribute = 'attr.scm.git';       glob = '.git';        group = 'scm';   },"
-			"	{ attribute = 'attr.scm.p4';        glob = '.p4config';   group = 'scm';   },"
-			"	{ attribute = 'attr.project.ninja'; glob = 'build.ninja'; group = 'build'; },"
-			"	{ attribute = 'attr.project.make';  glob = 'Makefile';    group = 'build'; },"
-			"	{ attribute = 'attr.project.xcode'; glob = '*.xcodeproj'; group = 'build'; },"
-			"	{ attribute = 'attr.project.rake';  glob = 'Rakefile';    group = 'build'; },"
+			"	{ attribute = 'attr.scm.svn';       glob = '.svn';           group = 'scm';   },"
+			"	{ attribute = 'attr.scm.hg';        glob = '.hg';            group = 'scm';   },"
+			"	{ attribute = 'attr.scm.git';       glob = '.git';           group = 'scm';   },"
+			"	{ attribute = 'attr.scm.p4';        glob = '.p4config';      group = 'scm';   },"
+			"	{ attribute = 'attr.project.ninja'; glob = 'build.ninja';    group = 'build'; },"
+			"	{ attribute = 'attr.project.make';  glob = 'Makefile';       group = 'build'; },"
+			"	{ attribute = 'attr.project.xcode'; glob = '*.xcodeproj';    group = 'build'; },"
+			"	{ attribute = 'attr.project.rake';  glob = 'Rakefile';       group = 'build'; },"
+			"	{ attribute = 'attr.project.ant';   glob = 'build.xml';      group = 'build'; },"
+			"	{ attribute = 'attr.project.cmake'; glob = 'CMakeLists.txt'; group = 'build'; },"
+			"	{ attribute = 'attr.project.maven'; glob = 'pom.xml';        group = 'build'; },"
+			"	{ attribute = 'attr.project.scons'; glob = 'SConstruct';     group = 'build'; },"
 			"); }";
 
 		std::vector<attribute_rule_t> res;


### PR DESCRIPTION
Add scope attributes for Ant, CMake, Maven and Scons projects for future improvement of ⌘B.
