### PR TITLE
New svn executable based Subversion scm driver

### DIFF
--- a/Frameworks/scm/src/drivers/api.cc
+++ b/Frameworks/scm/src/drivers/api.cc
@@ -71,13 +71,14 @@ namespace scm
 	driver_t* git_driver ();
 	driver_t* hg_driver ();
 	driver_t* p4_driver ();
+	driver_t* svn_driver ();
 
 	driver_t const* driver_for_path (std::string const& path, std::string* wcPath)
 	{
 		if(path == NULL_STR || path == "" || path[0] != '/')
 			return NULL;
 
-		static driver_t* const drivers[] = { git_driver(), hg_driver(), p4_driver() };
+		static driver_t* const drivers[] = { git_driver(), hg_driver(), p4_driver(), svn_driver() };
 		for(std::string cwd = path; cwd != "/"; cwd = path::parent(cwd))
 		{
 			iterate(driver, drivers)

--- a/Frameworks/scm/src/drivers/svn.cc
+++ b/Frameworks/scm/src/drivers/svn.cc
@@ -1,0 +1,103 @@
+#include "api.h"
+#include <oak/oak.h>
+#include <text/parse.h>
+#include <text/trim.h>
+#include <io/io.h>
+#include <oak/debug.h>
+
+OAK_DEBUG_VAR(SCM_Svn);
+
+static scm::status::type parse_status_flag (char flag)
+{
+	static struct { scm::status::type constant; char flag; } const StatusLetterConversionMap[] =
+	{
+		{ scm::status::added,       'A' },
+		{ scm::status::conflicted,  'C' },
+		{ scm::status::deleted,     'D' },
+		{ scm::status::ignored,     'I' },
+		{ scm::status::modified,    'M' },
+		{ scm::status::modified,    'R' }, // replaced with other version on server (uncommitted)
+		{ scm::status::unversioned, '?' },
+		{ scm::status::versioned,   ' ' }, // really means none but it implies it's an unchanged, versioned file
+		{ scm::status::deleted,     '!' }, // missing on disk
+	};
+
+	for(size_t i = 0; i < sizeofA(StatusLetterConversionMap); ++i)
+	{
+		if(flag == StatusLetterConversionMap[i].flag)
+			return StatusLetterConversionMap[i].constant;
+	}
+
+	ASSERT_EQ(flag, '\0'); // we use ‘flag’ in the assertion to output the unrecognized status flag
+	return scm::status::none;
+}
+
+static void parse_status_output (scm::status_map_t& entries, std::string const& output)
+{
+	if(output == NULL_STR)
+		return;
+
+	std::vector<std::string> v = text::split(output, "\n");
+	ASSERT_EQ(v.back(), "");
+	v.pop_back();
+	iterate(line, v)
+	{
+		// Subversion's status output uses the first 7 characters for status
+		ASSERT((*line).length() > 7);
+
+		std::string rel_path = text::trim(text::split((*line), "   ").back(), " \t\n");
+
+		if((*line)[1] != ' ')
+			entries[rel_path] = parse_status_flag((*line)[1]);
+		else
+			entries[rel_path] = parse_status_flag((*line)[0]);
+	}
+}
+
+static void collect_all_paths (std::string const& svn, scm::status_map_t& entries, std::string const& dir)
+{
+	ASSERT_NE(svn, NULL_STR);
+
+	std::map<std::string, std::string> env = oak::basic_environment();
+	env["PWD"] = dir;
+
+	// This does not return unmodified, versioned paths
+	parse_status_output(entries, io::exec(env, svn, "status", "--no-ignore", "-v", NULL));
+}
+
+namespace scm
+{
+	struct svn_driver_t : driver_t
+	{
+		svn_driver_t () : driver_t("svn", "%s/.svn", "svn") { }
+
+		std::string branch_name (std::string const& wcPath) const
+		{
+			if(executable() == NULL_STR)
+				return NULL_STR;
+
+			std::map<std::string, std::string> env = oak::basic_environment();
+			env["PWD"] = wcPath;
+
+			std::string info_output = io::exec(env, executable(), "info", NULL);
+			std::vector<std::string> v = text::split(info_output, "\n");
+
+			return text::split(v[2], ": ")[1];
+		}
+
+		status_map_t status (std::string const& wcPath) const
+		{
+			D(DBF_SCM_Svn, bug("%s\n", wcPath.c_str()););
+			if(executable() == NULL_STR)
+				return status_map_t();
+
+			status_map_t relativePaths, res;
+			collect_all_paths(executable(), relativePaths, wcPath);
+			iterate(pair, relativePaths)
+				res.insert(std::make_pair(path::join(wcPath, pair->first), pair->second));
+			return res;
+		}
+	};
+
+	driver_t* svn_driver () { return new svn_driver_t; }
+}

--- a/Frameworks/scm/tests/t_svn.cc
+++ b/Frameworks/scm/tests/t_svn.cc
@@ -1,0 +1,43 @@
+#include <scm/scm.h>
+#include <test/jail.h>
+#include <io/path.h>
+
+class svn_tests : public CxxTest::TestSuite
+{
+public:
+	void test_basic_status ()
+	{
+		test::jail_t jail;
+
+		TSM_ASSERT_EQUALS("\n\n  Unable to test subversion driver (svn executable not found).\n\n  To skip this test:\n    ninja scm/coerce\n\n  To install required executable (via MacPorts):\n    sudo port install subversion\n", system("which -s svn"), 0);
+
+		std::string const repoName = "tm-test-repo";
+		std::string const wcName = "tm-test-wc";
+		std::string const jailPath = jail.path();
+		std::string const script = text::format("{ cd '%s' && svnadmin create '%s' && svn co 'file://%s/%s' %s && cd '%s' && touch {clean,ignored,modified,added,missing,untracked}.txt && svn propset svn:ignore 'ignored.txt' . && svn add {clean,modified,missing}.txt && svn commit -m 'Initial commit' && svn add added.txt && svn rm missing.txt && echo foo > modified.txt; } >/dev/null", jailPath.c_str(), repoName.c_str(), jailPath.c_str(), repoName.c_str(), wcName.c_str(), wcName.c_str());
+
+		if(system(script.c_str()) != 0)
+		{
+			TS_FAIL(("error in setup: " + script).c_str());
+			return;
+		}
+
+		if(scm::info_ptr info = scm::info(jail.path(path::join(wcName, "clean.txt"))))
+		{
+			std::string expectedBranch = text::format("file://%s/%s", jailPath.c_str(), repoName.c_str());
+
+			TS_ASSERT_EQUALS(expectedBranch, info->branch());
+
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "clean.txt"))),     scm::status::versioned);
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "ignored.txt"))),   scm::status::ignored);
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "modified.txt"))),  scm::status::modified);
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "added.txt"))),     scm::status::added);
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "missing.txt"))),   scm::status::deleted);
+			TS_ASSERT_EQUALS(info->status(jail.path(path::join(wcName, "untracked.txt"))), scm::status::unversioned);
+		}
+		else
+		{
+			TS_FAIL(("error getting wc: " + jailPath).c_str());
+		}
+	}
+};


### PR DESCRIPTION
New svn executable based Subversion scm driver.
- Rewrote the Subversion SCM driver to use the svn executable
- Badges work just like Mercurial
- TM_SCM_BRANCH is set to the full repository URL for the working copy

See issue #273.
