### PR TITLE
Draw gutter selection block frame using gutter divider theme color.

### DIFF
--- a/Frameworks/OakTextView/src/GutterView.h
+++ b/Frameworks/OakTextView/src/GutterView.h
@@ -35,6 +35,7 @@ struct GVLineRecord
 	NSFont* lineNumberFont;
 	NSColor* foregroundColor;
 	NSColor* backgroundColor;
+	NSColor* dividerColor;
 	NSColor* selectionForegroundColor;
 	NSColor* selectionBackgroundColor;
 	id <GutterViewDelegate> delegate;
@@ -51,6 +52,7 @@ struct GVLineRecord
 @property (nonatomic, assign) id <GutterViewDelegate> delegate;
 @property (nonatomic, retain) NSColor* foregroundColor;
 @property (nonatomic, retain) NSColor* backgroundColor;
+@property (nonatomic, retain) NSColor* dividerColor;
 @property (nonatomic, retain) NSColor* selectionForegroundColor;
 @property (nonatomic, retain) NSColor* selectionBackgroundColor;
 - (void)setHighlightedRange:(std::string const&)str;

--- a/Frameworks/OakTextView/src/GutterView.mm
+++ b/Frameworks/OakTextView/src/GutterView.mm
@@ -41,7 +41,7 @@ struct data_source_t
 
 @implementation GutterView
 @synthesize partnerView, lineNumberFont, delegate;
-@synthesize foregroundColor, backgroundColor, selectionForegroundColor, selectionBackgroundColor;
+@synthesize foregroundColor, backgroundColor, dividerColor, selectionForegroundColor, selectionBackgroundColor;
 
 // ==================
 // = Setup/Teardown =
@@ -100,6 +100,7 @@ struct data_source_t
 	self.lineNumberFont  = nil;
 	self.foregroundColor = nil;
 	self.backgroundColor = nil;
+	self.dividerColor    = nil;
 	self.selectionForegroundColor = nil;
 	self.selectionBackgroundColor = nil;
 	iterate(it, columnDataSources)
@@ -345,7 +346,7 @@ static void DrawText (std::string const& text, CGRect const& rect, CGFloat basel
 	iterate(rect, backgroundRects)
 		NSRectFillUsingOperation(NSIntersectionRect(*rect, NSIntersectionRect(aRect, self.frame)), NSCompositeSourceOver);
 
-	[[self.foregroundColor colorWithAlphaComponent:0.75] set];
+	[self.dividerColor set];
 	iterate(rect, borderRects)
 		NSRectFillUsingOperation(NSIntersectionRect(*rect, NSIntersectionRect(aRect, self.frame)), NSCompositeSourceOver);
 

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -259,6 +259,7 @@ private:
 
 		gutterView.foregroundColor = [NSColor colorWithCGColor:styles.gutterForeground()];
 		gutterView.backgroundColor = [NSColor colorWithCGColor:styles.gutterBackground()];
+		gutterView.dividerColor = [NSColor colorWithCGColor:styles.gutterDivider()];
 		gutterScrollView.backgroundColor = gutterView.backgroundColor;
 		gutterView.selectionForegroundColor = [NSColor colorWithCGColor:styles.gutterSelectionForeground()];
 		gutterView.selectionBackgroundColor = [NSColor colorWithCGColor:styles.gutterSelectionBackground()];


### PR DESCRIPTION
Currently a line above and under gutter selection block is hardcoded as `.75 * foreground` while IMHO it should be exactly the same as `gutterDivider` color. So this change makes it happen.
