### PR TITLE
Fixed HTML Output negative height

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -73,7 +73,7 @@ OAK_DEBUG_VAR(DocumentController);
 
 	res["windowFrame"]        = to_s(NSStringFromRect([self.window frame]));
 	res["miniaturized"]       = [self.window isMiniaturized];
-	res["htmlOutputHeight"]   = htmlOutputView ? (int32_t)NSHeight(htmlOutputView.frame) : htmlOutputHeight;
+	res["htmlOutputHeight"]   = htmlOutputView ? (int32_t)NSHeight(htmlOutputView.frame) > 0 ? (int32_t)NSHeight(htmlOutputView.frame) : 0 : htmlOutputHeight;
 	res["fileBrowserVisible"] = !self.fileBrowserHidden;
 	res["fileBrowserWidth"]   = fileBrowser.view ? (int32_t)NSWidth(fileBrowser.view.frame) : fileBrowserWidth;
 


### PR DESCRIPTION
After dragging top border of HTML Output window down below the bottom of the main
window it cannot be dragged back and negative height of HTML Output is
saved to file. This patch fixes that by saving height as non-negative number.
