### PR TITLE
Set `TM_SCM_BRANCH` even for untitled document if possible

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -372,7 +372,7 @@ OAK_DEBUG_VAR(DocumentController);
 		{
 			[controller->textView performSelector:@selector(applicationDidBecomeActiveNotification:) withObject:aNotification];
 
-			settings_t const& settings = [controller selectedDocument]->settings();
+			settings_t const& settings = [controller selectedDocument]->settings(to_s([controller.untitledSavePath stringByAppendingPathComponent:DefaultSaveNameForDocument([controller selectedDocument])]));
 			controller.windowTitle = [NSString stringWithCxxString:settings.get(kSettingsWindowTitleKey, [controller selectedDocument]->display_name())];
 		}
 	}

--- a/Frameworks/DocumentWindow/src/DocumentTabs.mm
+++ b/Frameworks/DocumentWindow/src/DocumentTabs.mm
@@ -7,6 +7,7 @@
 #import <OakAppKit/NSAlert Additions.h>
 #import <document/collection.h>
 #import <document/session.h>
+#import <ns/ns.h>
 
 OAK_DEBUG_VAR(DocumentController_Tabs);
 
@@ -41,7 +42,7 @@ namespace
 	document::schedule_session_backup();
 
 	// This is also set after open succeeds
-	settings_t const& settings = [self selectedDocument]->settings();
+	settings_t const& settings = [self selectedDocument]->settings(to_s([self.untitledSavePath stringByAppendingPathComponent:DefaultSaveNameForDocument([self selectedDocument])]));
 	self.windowTitle      = [NSString stringWithCxxString:settings.get(kSettingsWindowTitleKey, [self selectedDocument]->display_name())];
 	self.representedFile  = [NSString stringWithCxxString:[self selectedDocument]->path()];
 	self.isDocumentEdited = [self selectedDocument]->is_modified();
@@ -76,7 +77,7 @@ namespace
 	D(DBF_DocumentController_Tabs, bug("\n"););
 	if(*aDocument == *[self selectedDocument])
 	{
-		settings_t const& settings = [self selectedDocument]->settings();
+		settings_t const& settings = [self selectedDocument]->settings(to_s([self.untitledSavePath stringByAppendingPathComponent:DefaultSaveNameForDocument([self selectedDocument])]));
 		self.windowTitle      = [NSString stringWithCxxString:settings.get(kSettingsWindowTitleKey, [self selectedDocument]->display_name())];
 		self.representedFile  = [NSString stringWithCxxString:[self selectedDocument]->path()];
 		self.isDocumentEdited = [self selectedDocument]->is_modified();
@@ -283,7 +284,7 @@ namespace
 		}
 	}
 
-	settings_t const& settings = aDocument->settings();
+	settings_t const& settings = aDocument->settings(to_s([self.untitledSavePath stringByAppendingPathComponent:DefaultSaveNameForDocument(aDocument)]));
 	self.windowTitle      = [NSString stringWithCxxString:settings.get(kSettingsWindowTitleKey, aDocument->display_name())];
 	self.representedFile  = [NSString stringWithCxxString:aDocument->path()];
 	self.isDocumentEdited = aDocument->is_modified();

--- a/Frameworks/document/src/document.cc
+++ b/Frameworks/document/src/document.cc
@@ -500,10 +500,12 @@ namespace document
 		return _file_type;
 	}
 
-	std::map<std::string, std::string> document_t::variables (std::map<std::string, std::string> map, bool sourceFileSystem) const
+	std::map<std::string, std::string> document_t::variables (std::map<std::string, std::string> map, bool sourceFileSystem, std::string const& untitledPath) const
 	{
 		map["TM_DISPLAYNAME"]   = display_name();
 		map["TM_DOCUMENT_UUID"] = to_s(identifier());
+
+		scm::info_ptr info;
 
 		if(path() != NULL_STR)
 		{
@@ -512,16 +514,20 @@ namespace document
 			map["TM_DIRECTORY"] = path::parent(path());
 			map["PWD"]          = path::parent(path());
 
-			if(scm::info_ptr info = scm::info(path()))
-			{
-				std::string const& branch = info->branch();
-				if(branch != NULL_STR)
-					map["TM_SCM_BRANCH"] = branch;
+			info = scm::info(path());
+		}
+		else if(untitledPath != NULL_STR)
+			info = scm::info(untitledPath);
 
-				std::string const& name = info->scm_name();
-				if(name != NULL_STR)
-					map["TM_SCM_NAME"] = name;
-			}
+		if(info)
+		{
+			std::string const& branch = info->branch();
+			if(branch != NULL_STR)
+				map["TM_SCM_BRANCH"] = branch;
+
+			std::string const& name = info->scm_name();
+			if(name != NULL_STR)
+				map["TM_SCM_NAME"] = name;
 		}
 
 		return sourceFileSystem ? variables_for_path(path(), scope(), map) : map;

--- a/Frameworks/document/src/document.h
+++ b/Frameworks/document/src/document.h
@@ -248,9 +248,13 @@ namespace document
 		std::string file_type () const;
 		std::string path_attributes () const  { return _path_attributes; }
 		scope::scope_t scope () const         { return file_type() + " " + path_attributes(); }
-		settings_t const settings () const    { return settings_for_path(virtual_path(), scope(), path::parent(_path), identifier(), variables(std::map<std::string, std::string>(), false)); }
 
-		std::map<std::string, std::string> variables (std::map<std::string, std::string> map, bool sourceFileSystem = true) const;
+		settings_t const settings (std::string const& untitledPath = NULL_STR) const
+		{
+			return settings_for_path(virtual_path(), scope(), path::parent(_path), identifier(), variables(std::map<std::string, std::string>(), false, untitledPath));
+		}
+
+		std::map<std::string, std::string> variables (std::map<std::string, std::string> map, bool sourceFileSystem = true, std::string const& untitledPath = NULL_STR) const;
 
 		bool is_modified () const;
 		bool is_on_disk () const                            { return is_open() ? _is_on_disk : path::exists(path());                }


### PR DESCRIPTION
It also **reloads window title on activate** (i.e. branch can be switched from console or other app), which is pretty substantial fix. Finally it adds `TM_SCM_NAME` variable.

Purpose of this commit is to see project / repo branch name when `$TM_SCM_BRANCH` is used in `windowTitle` when working on untitled document or opening some SCM managed folder. Without this change it does only display `untitled` and nothing else, so we need existing file open to see SCM branch.
