### PR TITLE
Fixed missing slash '/' in status bar infoString

### DIFF
--- a/Frameworks/OakFilterList/src/datasources/OakFileChooser.mm
+++ b/Frameworks/OakFilterList/src/datasources/OakFileChooser.mm
@@ -331,7 +331,7 @@ void file_chooser_t::wait () const
 	if(prefixLen == std::string::npos || prefixLen + name.size() != path.size() || prefixLen != 0 && path[prefixLen-1] != '/')
 		prefixLen = 0;
 	std::string const prefix = prefixLen ? path::with_tilde(path.substr(0, prefixLen)) : "";
-	return AttributedStringWithMarkedUpRanges(prefix.empty() ? path : prefix + name, data._match_ranges, prefix.size());
+	return AttributedStringWithMarkedUpRanges(prefix.empty() ? path : prefix + "/" + name, data._match_ranges, prefix.size());
 }
 @end
 


### PR DESCRIPTION
infoStrings as rendered in the status bar of the filter list view are missing a slash between the path and filename.
