### PR TITLE
only close empty document windows if the file browser is hidden

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentTabs.mm
+++ b/Frameworks/DocumentWindow/src/DocumentTabs.mm
@@ -260,7 +260,7 @@ namespace
 		documentTabs.erase(documentTabs.begin() + i);
 	}
 
-	if(documentTabs.empty())
+	if(documentTabs.empty() && self.fileBrowserHidden)
 		return [self close];
 
 	[tabBarView reloadData];


### PR DESCRIPTION
keep windows with a visible file browser open even after closing the last tab (open file).
this way, you can clean your view and still open files from the file browser.
