### PR TITLE
Replaced contents of skeleton svn_status.xsl with real content.

### DIFF
--- a/Frameworks/scm/resources/svn_status.xslt
+++ b/Frameworks/scm/resources/svn_status.xslt
@@ -1,1 +1,20 @@
-Hello world
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates select="/status/target"/>
+  </xsl:template>
+
+  <xsl:template match="/status/target/entry">
+    <xsl:value-of select="@path" />
+  </xsl:template>
+
+  <!-- Write out parseable format: FILE_PATH    FILE_STATUS    FILE_PROPS_STATUS -->
+  <xsl:template match="/status/target/entry">
+     <xsl:value-of select="@path"/>
+     <xsl:value-of select="'    '"/>
+     <xsl:value-of select="wc-status/@item"/>
+     <xsl:value-of select="'    '"/>
+     <xsl:value-of select="wc-status/@props"/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
- Note: Column delimiter is back to four spaces due to XML/XSL not allowing control characters
