### PR TITLE
Add showUrl:from: to OakFileBrowser mimicking TM1 style for show current document

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -925,7 +925,10 @@ OAK_DEBUG_VAR(DocumentController);
 	NSURL* currentDocumentURL = [NSURL fileURLWithPath:[NSString stringWithCxxString:[self selectedDocument]->path()]];
 	if([fileBrowser.selectedURLs count] == 1 && [currentDocumentURL isEqualTo:[fileBrowser.selectedURLs lastObject]])
 			[fileBrowser deselectAll:self];
-	else	[fileBrowser showURL:currentDocumentURL];
+	else {
+		// [fileBrowser showURL:currentDocumentURL];
+		[fileBrowser showURL:currentDocumentURL from:[NSURL fileURLWithPath:self.projectPath]];
+	}
 }
 
 - (IBAction)goToProjectFolder:(id)sender

--- a/Frameworks/OakFileBrowser/src/OakFileBrowser.h
+++ b/Frameworks/OakFileBrowser/src/OakFileBrowser.h
@@ -39,6 +39,7 @@ PUBLIC @interface OakFileBrowser : NSResponder <OFBOutlineViewMenuDelegate>
 
 - (void)setupViewWithSize:(NSSize)viewSize resizeIndicatorOnRight:(BOOL)flag state:(NSDictionary*)fileBrowserState;
 - (void)showURL:(NSURL*)aPath;
+- (void)showURL:(NSURL*)aPath from:(NSURL*)rootPath;
 - (void)deselectAll:(id)sender;
 - (void)updateVariables:(std::map<std::string, std::string>&)env;
 


### PR DESCRIPTION
When hitting "Go > Current Document" instead of entering the current doc
folder it shows the whole path from the project folder to the file.
