### PR TITLE
Add .ai and .gif to the binary list in default tmProperties

### DIFF
--- a/Applications/TextMate/resources/Default.tmProperties
+++ b/Applications/TextMate/resources/Default.tmProperties
@@ -4,7 +4,7 @@ fontSize = 12
 
 exclude  = "{*.{o,pyc},Icon\r,CVS,_darcs,_MTN,\{arch\},blib,*~.nib}"
 include  = "{*,.tm_properties,.htaccess}"
-binary   = "{*.{icns,ico,jpg,jpeg,m4v,nib,o,pdf,png,psd,pyc,rtf,tif,tiff,xib},Icon\r}"
+binary   = "{*.{ai,gif,icns,ico,jpg,jpeg,m4v,nib,o,pdf,png,psd,pyc,rtf,tif,tiff,xib},Icon\r}"
 
 windowTitleSCM = '${TM_SCM_BRANCH:+ ($TM_SCM_NAME: $TM_SCM_BRANCH)}'
 windowTitle    = '$TM_DISPLAYNAME$windowTitleSCM'


### PR DESCRIPTION
Noticed that searches were going through gif files as well as the couple illustrator files in my project. 

Thought I may as well and try my luck at being an Official Textmate Committer™ 

:) 
