### PR TITLE
Make bundle release notes viewer HTML page

### DIFF
--- a/Applications/TextMate/resources/bundle_release_notes.html
+++ b/Applications/TextMate/resources/bundle_release_notes.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="./css/stylesheet.css">
+  <style type="text/css">
+  .cross {
+    cursor: pointer;
+  }
+  .commit_body {
+    font-size: 9pt;
+  }
+  .bundle_name {
+    font-weight: bold;
+  }
+  .bundle_name:after {
+    content: ': ';
+  }
+  </style>
+  <script type="text/javascript">
+  var mainContainer = null;
+  
+  var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  
+  function Group(name, identifier) {
+    var self = this;
+    self.identifier = identifier;
+    
+    // header text
+    var heading = document.createElement('h2');
+    heading.appendChild(document.createTextNode(name));
+    mainContainer.appendChild(heading);
+    
+    // commit list
+    var list = document.createElement('ul');
+    mainContainer.appendChild(list);
+    
+    self.add = function(commit) {
+      list.appendChild(commit.node);
+    }
+  }
+  
+  function Commit(commit, bundleName) {
+    var self = this;
+    var item = document.createElement('li');
+    
+    var para = document.createElement('p');
+    item.appendChild(para);
+    
+    // name of the bundle
+    var nameBox = document.createElement('span');
+    nameBox.appendChild(document.createTextNode(bundleName));
+    nameBox.className = 'bundle_name';
+    para.appendChild(nameBox);
+    
+    // summary
+    para.innerHTML += commit.summary + ' ';
+    
+    // author
+    var by = document.createElement('span');
+    by.className = 'credit';
+    by.appendChild(document.createTextNode(commit.author));
+    para.appendChild(by);
+    
+    // body text with cross open and close body
+    if (commit.body != '') {
+      var openCross = ' [+]';
+      var closedCross = ' [–]';
+      
+      var cross = document.createElement('span');
+      cross.className = 'cross';
+      cross.appendChild(document.createTextNode(openCross));
+      para.appendChild(cross);
+      
+      // the body text
+      var more = document.createElement('p');
+      more.className = 'commit_body';
+      more.innerHTML = commit.body;
+      para.appendChild(more);
+      more.style.display = 'none';
+      
+      // click the cross event
+      cross.addEventListener('click', function(e) {
+        e.preventDefault();
+        more.style.display = more.style.display == 'none' ? 'block' : 'none';
+        cross.innerText = more.style.display == 'none' ? openCross : closedCross;
+      })
+    }
+    
+    self.node = item;
+  }
+  
+  function setJSON(raw) {
+    var json = JSON.parse(raw);
+    var commits = [];
+    
+    // clean box
+    mainContainer.innerHTML = '';
+    
+    // parse commit dates and flatten list
+    for (var i = 0; i < json.bundles.length; i++) {
+      for (var j = 0; j < json.bundles[i].commits.length; j++) {
+        var commit = json.bundles[i].commits[j];
+        commit.date = new Date(commit.date);
+        commit.bundleId = i;
+        commits.push(commit);
+      }
+    }
+    
+    commits.sort(function(a, b) {
+      return b.date - a.date;
+    });
+    
+    // generate the HTML
+    var currentGroup = null;
+    for (var i = 0; i < commits.length; i++) {
+      var commit = commits[i];
+      var identifier = monthNames[commit.date.getMonth()] + ', ' + commit.date.getFullYear();
+      if (currentGroup == null || currentGroup.identifier != identifier) {
+        // create group block
+        currentGroup = new Group(identifier, identifier);
+      }
+      // add commit
+      currentGroup.add(new Commit(commit, json.bundles[commit.bundleId].name));
+    }
+  }
+  window.addEventListener('load', function() {
+    mainContainer = document.getElementById('wrapper');
+  })
+  </script>
+</head>
+<body>
+  <h1 id="releasenotes">Bundle Release Notes</h1>
+  <article id="wrapper"></article>
+</body>
+</html>


### PR DESCRIPTION
I made a bundle release notes viewer that takes a raw JSON string as input using the setJSON() function. You are meant to feed this function the release notes data as a JavaScript string.
