### PR TITLE
Apply default gutter theme when no theme is active.

### DIFF
--- a/Frameworks/theme/src/theme.cc
+++ b/Frameworks/theme/src/theme.cc
@@ -166,30 +166,29 @@ void theme_t::setup_styles ()
 	_styles.clear();
 	_cache.clear();
 
-	if(!_item)
-		return;
-
-	if(bundles::item_ptr newItem = bundles::lookup(_item->uuid()))
-		_item = newItem;
-
-	plist::array_t items;
-	if(plist::get_key_path(_item->plist(), "settings", items))
+	if(_item)
 	{
-		iterate(it, items)
+		if(bundles::item_ptr newItem = bundles::lookup(_item->uuid()))
+			_item = newItem;
+
+		plist::array_t items;
+		if(plist::get_key_path(_item->plist(), "settings", items))
 		{
-			if(plist::dictionary_t const* styles = boost::get<plist::dictionary_t>(&*it))
+			iterate(it, items)
 			{
-				_styles.push_back(parse_styles(*styles));
-				if(!_styles.back().invisibles.is_blank())
+				if(plist::dictionary_t const* styles = boost::get<plist::dictionary_t>(&*it))
 				{
-					decomposed_style_t invisbleStyle("deco.invisible");
-					invisbleStyle.foreground = _styles.back().invisibles;
-					_styles.push_back(invisbleStyle);
+					_styles.push_back(parse_styles(*styles));
+					if(!_styles.back().invisibles.is_blank())
+					{
+						decomposed_style_t invisbleStyle("deco.invisible");
+						invisbleStyle.foreground = _styles.back().invisibles;
+						_styles.push_back(invisbleStyle);
+					}
 				}
 			}
 		}
 	}
-
 	// =======================================
 	// = Find “global” foreground/background =
 	// =======================================
@@ -211,7 +210,7 @@ void theme_t::setup_styles ()
 	_gutter_styles.selectionBackground = soften(_background, 0.95);
 
 	plist::dictionary_t gutterSettings;
-	if(plist::get_key_path(_item->plist(), "gutterSettings", gutterSettings))
+	if(_item && plist::get_key_path(_item->plist(), "gutterSettings", gutterSettings))
 	{
 		static struct { std::string const key; cf::color_t gutter_styles_t::*field; } const gutterKeys[] =
 		{

--- a/Frameworks/theme/target
+++ b/Frameworks/theme/target
@@ -1,3 +1,4 @@
+TEST_SOURCES = tests/*.cc
 SOURCES      = src/*.cc
 LINK        += text bundles cf plist scope
 EXPORT       = src/*.h

--- a/Frameworks/theme/tests/t_theme.cc
+++ b/Frameworks/theme/tests/t_theme.cc
@@ -1,0 +1,23 @@
+#include <theme/theme.h>
+
+class ThemeTests : public CxxTest::TestSuite
+{
+public:
+	void test_missing_theme_item_still_sets_gutter_colors ()
+	{
+		theme_t theme(NULL);
+		auto gutter = theme.gutter_styles();
+		TS_ASSERT_EQUALS(to_s(gutter.divider),               "#666666FF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionBorder),       "#666666FF");
+		TS_ASSERT_EQUALS(to_s(gutter.foreground),            "#808080FF");
+		TS_ASSERT_EQUALS(to_s(gutter.background),            "#212121FF");
+		TS_ASSERT_EQUALS(to_s(gutter.icons),                 "#808080FF");
+		TS_ASSERT_EQUALS(to_s(gutter.iconsHover),            "#808080FF");
+		TS_ASSERT_EQUALS(to_s(gutter.iconsPressed),          "#808080FF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionForeground),   "#F2F2F2FF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionBackground),   "#0D0D0DFF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionIcons),        "#F2F2F2FF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionIconsHover),   "#F2F2F2FF");
+		TS_ASSERT_EQUALS(to_s(gutter.selectionIconsPressed), "#F2F2F2FF");
+	}
+};


### PR DESCRIPTION
Previously, if no themes were active, the gutter colors would
not be set.  This would, effectively, give you random gutter colors
on TextMate startup. (or, sometimes, a completely transparent gutter).

I hereby release this patch into the public domain.
