### PR TITLE
Update README to indicate pre-built app in .tbz not download zip or tar.gz'd repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the source code for TextMate 2, a text editor for OS X 
 
 ## Important
 
-If you just want to run TextMate 2 then download a [prebuilt binary][]. For 10.6 support you can try a [10.6 build][] (from the [10.6 fork][]) but it comes with no guarantee of actually working!
+If you just want to run TextMate 2 then download a [prebuilt binary][]. Be sure to download a `.tbz`, as the "Download as zip" and "Download as tar.gz" will just download snapshots of the repository. For 10.6 support you can try a [10.6 build][] (from the [10.6 fork][]) but it comes with no guarantee of actually working!
 
 If you have problems building please **don’t** open an issue! Instead write the [textmate-dev][] mailing list or use the [#textmate][] IRC channel on [freenode.net][] where people might be able to help you.
 


### PR DESCRIPTION
Updated README to indicate .tbz is prebuilt binary, not the GitHub buttons to download the compressed repository. Zip and tar.gz are more familiar to people than tbz, so they are more likely to download those intending to download the pre-built version.
