### PR TITLE
allow someone to completely disable open and modified tracking

### DIFF
--- a/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
+++ b/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
@@ -203,6 +203,9 @@ static bool is_binary (std::string const& path)
 
 - (void)setOpenURLs:(NSArray*)newOpenURLs
 {
+	if(!settings_for_path(NULL_STR, "", [self.location UTF8String]).get<bool>(kSettingsFBTrackOpenModifiedKey, true))
+		return;
+	
 	if([outlineViewDelegate.openURLs isEqualToArray:newOpenURLs])
 		return;
 
@@ -217,6 +220,9 @@ static bool is_binary (std::string const& path)
 
 - (void)setModifiedURLs:(NSArray*)newModifiedURLs
 {
+	if(!settings_for_path(NULL_STR, "", [self.location UTF8String]).get<bool>(kSettingsFBTrackOpenModifiedKey, true))
+		return;
+	
 	if([outlineViewDelegate.modifiedURLs isEqualToArray:newModifiedURLs])
 		return;
 

--- a/Frameworks/settings/src/keys.cc
+++ b/Frameworks/settings/src/keys.cc
@@ -18,6 +18,7 @@ std::string const kSettingsShowInvisiblesKey              = "showInvisibles";
 
 std::string const kSettingsProjectDirectoryKey            = "projectDirectory";
 std::string const kSettingsSCMStatusKey                   = "scmStatus";
+std::string const kSettingsFBTrackOpenModifiedKey			 = "fbTrackOpenModified";
 std::string const kSettingsWindowTitleKey                 = "windowTitle";
 std::string const kSettingsScopeAttributesKey             = "scopeAttributes";
 

--- a/Frameworks/settings/src/keys.h
+++ b/Frameworks/settings/src/keys.h
@@ -21,6 +21,7 @@ PUBLIC extern std::string const kSettingsShowInvisiblesKey;
 
 PUBLIC extern std::string const kSettingsProjectDirectoryKey;
 PUBLIC extern std::string const kSettingsSCMStatusKey;
+PUBLIC extern std::string const kSettingsFBTrackOpenModifiedKey;
 PUBLIC extern std::string const kSettingsWindowTitleKey;
 PUBLIC extern std::string const kSettingsScopeAttributesKey;
 


### PR DESCRIPTION
allow someone to completely disable open and modified tracking with the fbTrackOpenModified=false setting
