### PR TITLE
Always enable the TM_SOFT_TABS variable.

### DIFF
--- a/Frameworks/editor/src/editor.cc
+++ b/Frameworks/editor/src/editor.cc
@@ -1357,7 +1357,8 @@ namespace ng
 
 		map.insert(std::make_pair("TM_TAB_SIZE", text::format("%zu", _buffer.indent().tab_size())));
 		if(_buffer.indent().soft_tabs())
-			map.insert(std::make_pair("TM_SOFT_TABS", "YES"));
+				map.insert(std::make_pair("TM_SOFT_TABS", "YES"));
+		else	map.insert(std::make_pair("TM_SOFT_TABS", "NO"));
 		map.insert(std::make_pair("TM_SELECTION", to_s(_buffer, _selections)));
 
 		if(_selections.size() == 1)


### PR DESCRIPTION
Backwards compatibility for commands that expect the variable to always exist or match the NO state, this matches the behavior of 1.x.
