### PR TITLE
Support accessibility in text view - VoiceOver and Zoom

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -2151,6 +2151,18 @@ static void update_menu_key_equivalents (NSMenu* menu, action_to_key_t const& ac
 	[selectionString release];
 	selectionString = [aSelectionString copy];
 	NSAccessibilityPostNotification(self, NSAccessibilitySelectedTextChangedNotification);
+	if (UAZoomEnabled())
+	{
+		NSRange selectedRange  = [[self accessibilityAttributeValue:NSAccessibilitySelectedTextRangeAttribute] rangeValue];
+		NSRect  selectedRect   = [[self accessibilityAttributeValue:NSAccessibilityBoundsForRangeParameterizedAttribute forParameter:[NSValue valueWithRange:selectedRange]] rectValue];
+		NSRect  viewRect       = [self convertRect:[self visibleRect] toView:nil];
+		viewRect = [[self window] convertRectToScreen:viewRect];
+		viewRect.origin.y = [[NSScreen mainScreen] frame].size.height - (viewRect.origin.y + viewRect.size.height);
+		selectedRect.origin.y = [[NSScreen mainScreen] frame].size.height - (selectedRect.origin.y + selectedRect.size.height);
+		if (selectedRect.size.width == -1)
+			selectedRect.size.width = 1;
+		UAZoomChangeFocus(&viewRect, &selectedRect, kUAZoomFocusTypeInsertionPoint);
+	}
 	if(isUpdatingSelection)
 		return;
 


### PR DESCRIPTION
These commits enable visually impaired and blind users on OS X to use VoiceOver and Zoom in the text component of TextMate. Both commits contain a bit more detailed description of the changes.

I have a few points which might use some discussion:
- is [OakTextView setSelectionString] the right place to track selection changes? It feels this is not the place where the selection model is defined (it is I guess in document or editor objects), but just reflected. I had no problem to find the right place for tracking of text model changes (buffer callbacks), but no luck finding right place to track selection model changes. However, tracking selection in setSelectionString seems to work absolutely fine.
- the nsRangeForRange and rangeForNSRange methods could be optimized for O(log n) in similar way as basic_tree_t is (as noted in the code comment). These methods could also be used in the relevant NSTextInput methods instead of the manual code currently present there - if there is interest, I can make a follow-up commit to use them for that code as well.

Both patches (commits) are released as public domain by my employer, BRAILCOM,o.p.s.
