### PR TITLE
Make OakPasteboardSelector accessible

### DIFF
--- a/Frameworks/OakAppKit/src/OakPasteboardSelector.mm
+++ b/Frameworks/OakAppKit/src/OakPasteboardSelector.mm
@@ -54,6 +54,35 @@ static size_t line_count (std::string text)
 	}
 }
 
+- (NSArray *)accessibilityAttributeNames
+{
+	static NSArray* attributes = nil;
+	if(!attributes)
+	{
+		NSSet* set = [NSSet setWithArray:[super accessibilityAttributeNames]];
+
+		set = [set setByAddingObjectsFromArray:@[
+			NSAccessibilityRoleAttribute,
+			NSAccessibilityValueAttribute,
+		]];
+		attributes = [[set allObjects] retain];
+	}
+	return attributes;
+}
+
+- (id)accessibilityAttributeValue:(NSString *)attribute
+{
+	id value = nil;
+	if([attribute isEqualToString:NSAccessibilityRoleAttribute]) {
+		value = NSAccessibilityStaticTextRole;
+	} else if([attribute isEqualToString:NSAccessibilityValueAttribute]) {
+		value = [self objectValue];
+	} else {
+		value = [super accessibilityAttributeValue:attribute];
+	}
+	return value;
+}
+
 - (size_t)lineCountForText:(NSString*)text
 {
 	return oak::cap((size_t)1, line_count([text UTF8String]), maxLines);


### PR DESCRIPTION
Issues remaining:
- VoiceOver for some reason cannot track keyboard focus
  (i.e. moving down the list with just down arrow does not move
  VoiceOver cursor). User has to move the VO cursor instead using VO-down
  (and keyboard cursor follows in this case)
- the pasteboard window isn't focused automatically for VoiceOver, user
  has to switch manually to it using VO-F2-F2

Released to public domain by my employer, BRAILCOM,o.p.s.
