### PR TITLE
add "Open in Finder" context menu when no items are selected

### DIFF
--- a/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
+++ b/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
@@ -551,6 +551,11 @@ static NSMutableSet* SymmetricDifference (NSMutableSet* aSet, NSMutableSet* anot
 	}
 }
 
+- (void)openCurrentFolderInFinder:(id)sender
+{
+	[[NSWorkspace sharedWorkspace] openURL:_url];
+}
+
 - (void)showSelectedEntriesInFinder:(id)sender
 {
 	for(FSItem* item in self.selectedItems)
@@ -687,6 +692,8 @@ static NSMutableSet* SymmetricDifference (NSMutableSet* aSet, NSMutableSet* anot
 	{
 		if([_url isFileURL])
 		{
+			[menu addItemWithTitle:@"Open in Finder" action:@selector(openCurrentFolderInFinder:) keyEquivalent:@""];
+			[menu addItem:[NSMenuItem separatorItem]];
 			[menu addItemWithTitle:@"New Folder" action:@selector(newFolderInSelectedFolder:) keyEquivalent:@""];
 			[menu addItemWithTitle:@"Add to Favorites" action:@selector(addSelectedEntriesToFavorites:) keyEquivalent:@""];
 		}


### PR DESCRIPTION
When you control-click the empty part of the file browser and select "Open in Finder" a Finder window will open showing the currently selected folder.

You can go about this other ways, but I find that this feature complements the already existing "New Folder" menu item in the no-items-selected context menu of the file browser.

This patch is public domain.
