### PR TITLE
Added force open in TextMate and fixed confusion when opening an alias.

### DIFF
--- a/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
+++ b/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
@@ -777,16 +777,17 @@ static NSMutableSet* SymmetricDifference (NSMutableSet* aSet, NSMutableSet* anot
 		NSURL* itemURL = item.target ?: item.url;
 
 		FSItemURLType type = item.urlType;
-		if(type == FSItemURLTypePackage && OakIsAlternateKeyOrMouseEvent())
-			type = FSItemURLTypeFolder;
-		else if(type == FSItemURLTypeFile && is_binary([itemURL.path fileSystemRepresentation]))
-			type = FSItemURLTypePackage;
-		else if(type == FSItemURLTypeAlias)
+		if(type == FSItemURLTypeAlias)
 		{
 			FSItem* tmp = [FSItem itemWithURL:[NSURL fileURLWithPath:[NSString stringWithCxxString:path::resolve([itemURL.path fileSystemRepresentation])]]];
 			type    = tmp.urlType;
 			itemURL = tmp.target ?: tmp.url;
 		}
+		
+		if(type == FSItemURLTypePackage && OakIsAlternateKeyOrMouseEvent())
+			type = FSItemURLTypeFolder;
+		else if(type == FSItemURLTypeFile && is_binary([itemURL.path fileSystemRepresentation]) && !OakIsAlternateKeyOrMouseEvent())
+			type = FSItemURLTypePackage;
 
 		switch(type)
 		{


### PR DESCRIPTION
Any file should be able to be opened within TextMate, so Option-DblClick will always do that. I first noticed this being useful with .xib files.

Because of the order of the if statements, opening an alias to a package or binary file (or .xib) would not have the previous if statements applied to it. So an alias to a .xib would actually always open in TextMate, but only because of mis-ordered logic.
