### PR TITLE
Focus ring and color changes for Go to File

### DIFF
--- a/Frameworks/OakFilterList/src/FileChooser.mm
+++ b/Frameworks/OakFilterList/src/FileChooser.mm
@@ -295,14 +295,14 @@ static path::glob_list_t globs_for_path (std::string const& path)
 
 		NSDictionary* views = @{
 			@"searchField"        : _searchField,
-			@"aboveScopeBarDark"  : OakCreateViewWithColor([NSColor grayColor]),
+			@"aboveScopeBarDark"  : OakCreateViewWithColor([NSColor grayColor], [NSColor lightGrayColor]),
 			@"aboveScopeBarLight" : OakCreateViewWithColor([NSColor colorWithCalibratedWhite:1.000 alpha:0.300]),
 			@"allButton"          : _allButton,
 			@"openFilesButton"    : _openDocumentsButton,
 			@"scmChangesButton"   : _scmChangesButton,
-			@"topDivider"         : OakCreateViewWithColor([NSColor darkGrayColor]),
+			@"topDivider"         : OakCreateViewWithColor([NSColor darkGrayColor], [NSColor colorWithCalibratedWhite:0.551 alpha:1.000]),
 			@"scrollView"         : scrollView,
-			@"bottomDivider"      : OakCreateViewWithColor([NSColor grayColor]),
+			@"bottomDivider"      : OakCreateViewWithColor([NSColor grayColor], [NSColor lightGrayColor]),
 			@"statusTextField"    : _statusTextField,
 			@"itemCountTextField" : _itemCountTextField,
 			@"progressIndicator"  : _progressIndicator,


### PR DESCRIPTION
- For aesthetic reasons the focus ring is disabled as there is no other control that can be active, however this is not the case with full keyboard access enabled as you can tab through the scope bar as well.
- Add inactive state coloring for dividers.
