### PR TITLE
Fixes window bg randomly going crazy on startup

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -240,6 +240,10 @@ namespace
 		self.window.contentView                 = self.layoutView;
 		self.window.delegate                    = self;
 		self.window.releasedWhenClosed          = NO;
+		[self.window setContentBorderThickness:0 forEdge:NSMaxYEdge]; // top border
+		[self.window setContentBorderThickness:0 forEdge:NSMinYEdge]; // bottom border
+		[self.window setAutorecalculatesContentBorderThickness:NO forEdge:NSMaxYEdge];
+		[self.window setAutorecalculatesContentBorderThickness:NO forEdge:NSMinYEdge];
 		[self.window bind:@"title" toObject:self withKeyPath:@"windowTitle" options:nil];
 		[self.window bind:@"documentEdited" toObject:self withKeyPath:@"isDocumentEdited" options:nil];
 


### PR DESCRIPTION
After recent auto-layout changes the default `auto` settings for main textured window's content border thickness goes crazy, as a result we get weird title bar light background:
![Zrzut ekranu 2013-01-30 o 00 29 58](https://f.cloud.github.com/assets/103067/109133/03e54f26-6a6c-11e2-93d7-9e6814ddb34d.png)

This patch provides simple workaround setting fixes zero border with `setContentBorderThickness:` as described at:
http://stackoverflow.com/questions/5812593/nswindow-textured-gradient-fill-weirdness
http://stackoverflow.com/questions/7795505/nswindow-textured-background-with-nstextfield/11482772#11482772
