### PR TITLE
Line-up tab bar height with file browser header

### DIFF
--- a/Frameworks/OakAppKit/resources/TabBar.plist
+++ b/Frameworks/OakAppKit/resources/TabBar.plist
@@ -143,7 +143,7 @@
       { rect = (   1, W-2,   2, H-2 ); action = 'selectTab:'; requisite = mouse_clicked; toolTip = 1; },
       { rect = (   1, W-2,   2, H-2 ); action = 'dragTab:'; requisite = mouse_dragged; },
       { rect = (   1, W-2,   2, H-2 ); action = 'didDoubleClickTab:'; requisite = mouse_double_clicked; },
-      { rect = (  23, W-8,   4, H-7 ); text = { shadow = 1; }; },
+      { rect = (  23, W-8,   4, H-7 ); text = { shadow = 1; bold = 1; }; },
 
       { rect = (   5,  16,   6,  18 ); requisiteMask = 'mouse_inside|modified';               requisite = '';                                    image = "TabClose";                  },
       { rect = (   5,  16,   6,  18 ); requisiteMask = 'mouse_inside|modified';               requisite = 'modified';                            image = "TabClose_Modified";         },

--- a/Frameworks/OakAppKit/src/OakControl Private.h
+++ b/Frameworks/OakAppKit/src/OakControl Private.h
@@ -54,7 +54,12 @@ struct layer_t
 	objc_ptr<NSImage*> image;
 	objc_ptr<NSString*> tool_tip;
 	objc_ptr<NSView*> view;
-	enum text_options_t { none, shadow };
+	enum text_options_t
+	{
+		none   = (      0),
+		shadow = (1 <<  1),
+		bold   = (1 <<  2),
+	};
 	uint32_t text_options;
 	enum image_options_t { no_repeat, stretch, /* repeat_x, repeat_y, repeat_xy */ };
 	uint32_t image_options;
@@ -81,4 +86,4 @@ struct layer_t
 - (void)sendAction:(SEL)action fromLayer:(layer_t const&)aLayer;
 @end
 
-double WidthOfText (NSString* string);
+double WidthOfText (NSString* string, bool bold = false);

--- a/Frameworks/OakAppKit/src/OakControl.mm
+++ b/Frameworks/OakAppKit/src/OakControl.mm
@@ -7,7 +7,7 @@
 static CFAttributedStringRef AttributedStringWithOptions (NSString* string, uint32_t options, NSLineBreakMode lineBreakMode = NSLineBreakByTruncatingTail)
 {
 	NSMutableDictionary* attr = [NSMutableDictionary dictionary];
-	attr[NSFontAttributeName] = [NSFont controlContentFontOfSize:[NSFont smallSystemFontSize]];
+	attr[NSFontAttributeName] = (options & layer_t::bold) ? [NSFont boldSystemFontOfSize:[NSFont smallSystemFontSize]] : [NSFont controlContentFontOfSize:[NSFont smallSystemFontSize]];
 
 	NSMutableParagraphStyle* paragraph = [[NSMutableParagraphStyle new] autorelease];
 	[paragraph setLineBreakMode:lineBreakMode];
@@ -17,11 +17,11 @@ static CFAttributedStringRef AttributedStringWithOptions (NSString* string, uint
 	return (CFAttributedStringRef)res;
 }
 
-double WidthOfText (NSString* string)
+double WidthOfText (NSString* string, bool bold)
 {
 	double width = 0;
 
-	CTLineRef line = CTLineCreateWithAttributedString(AttributedStringWithOptions(string, 0));
+	CTLineRef line = CTLineCreateWithAttributedString(AttributedStringWithOptions(string, bold ? layer_t::bold : 0));
 	width          = CTLineGetTypographicBounds(line, NULL, NULL, NULL);
 	CFRelease(line);
 

--- a/Frameworks/OakAppKit/src/OakTabBarView.mm
+++ b/Frameworks/OakAppKit/src/OakTabBarView.mm
@@ -283,7 +283,9 @@ layout_metrics_t::raw_layer_t layout_metrics_t::parse_layer (NSDictionary* item)
 	{
 		res.has_label = true;
 		if([[textOptions objectForKey:@"shadow"] boolValue])
-			res.layer.text_options = res.layer.text_options | layer_t::shadow;
+			res.layer.text_options |= layer_t::shadow;
+		if([[textOptions objectForKey:@"bold"] boolValue])
+			res.layer.text_options |= layer_t::bold;
 	}
 	if([[item objectForKey:@"toolTip"] boolValue])
 		res.has_tool_tip = true;
@@ -587,7 +589,7 @@ static id SafeObjectAtIndex (NSArray* array, NSUInteger index)
 	double totalWidth = 0;
 	for(NSUInteger tabIndex = 0; tabIndex < tabTitles.count; ++tabIndex)
 	{
-		double width = WidthOfText(SafeObjectAtIndex(tabTitles, tabIndex));
+		double width = WidthOfText(SafeObjectAtIndex(tabTitles, tabIndex), true); // FIXME: remove hardcoded bold
 		citerate(it, metrics->layers_for([self layerNameForTabIndex:tabIndex], CGRectZero, tabIndex, @"LabelPlaceholder"))
 		{
 			if(it->text)


### PR DESCRIPTION
1st commit: Slightly enlarging tab bar height so it seamlessly integrates with file navigation header.
2nd (optional) commit: Bumps little bit lightness of tab bar as it is hardly readable right now (above new vs below old).
3rd (optional) commit: Makes tab bar labels bold like in other apps: Xcode, Safari.

@sorbits I know @infininight is in charge of the design, so these are just temporary changes to line up with tabs above document. And if you don't want to merge them, fine. At least anyone impatient like me would be able to merge these out of this ticket from my branch and build TM version with stuff properly aligned.

Look after the changes:
![now](https://f.cloud.github.com/assets/103067/114881/731fbb7c-6bb8-11e2-9336-5926ac35ce42.jpg)

Before:
![was](https://f.cloud.github.com/assets/103067/114883/77cb6fb8-6bb8-11e2-9067-e10ca1923435.jpg)
