### PR TITLE
Don't mutate shared themes

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -457,10 +457,9 @@ static std::string shell_quote (std::vector<std::string> paths)
 		theme          = parse_theme(bundles::lookup(settings.get(kSettingsThemeKey, NULL_STR)));
 		fontName       = settings.get(kSettingsFontNameKey, NULL_STR);
 		fontSize       = settings.get(kSettingsFontSizeKey, 11);
+		theme          = theme->copy_with_font_name_and_size(fontName, fontSize);
 		showInvisibles = settings.get(kSettingsShowInvisiblesKey, false);
 		antiAlias      = ![[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsDisableAntiAliasKey];
-
-		theme->set_font_name_and_size(fontName, fontSize);
 
 		spellingDotImage = [[NSImage imageNamed:@"SpellingDot" inSameBundleAsClass:[self class]] retain];
 		foldingDotsImage = [[NSImage imageNamed:@"FoldingDots" inSameBundleAsClass:[self class]] retain];

--- a/Frameworks/layout/src/layout.cc
+++ b/Frameworks/layout/src/layout.cc
@@ -91,7 +91,7 @@ namespace ng
 	{
 		if(fontName == _theme->font_name() && fontSize == _theme->font_size())
 			return;
-		_theme->set_font_name_and_size(fontName, fontSize);
+		_theme = _theme->copy_with_font_name_and_size(fontName, fontSize);
 		setup_font_metrics();
 		clear_text_widths();
 	}

--- a/Frameworks/layout/tests/t_layout.mm
+++ b/Frameworks/layout/tests/t_layout.mm
@@ -133,7 +133,7 @@ private:
 			buffer.set_grammar(*item);
 
 		theme_ptr theme = parse_theme(bundles::lookup("71D40D9D-AE48-11D9-920A-000D93589AF6"));
-		theme->set_font_name_and_size("Gill Sans", 14);
+		theme = theme->copy_with_font_name_and_size("Gill Sans", 14);
 		layout.reset(new ng::layout_t(buffer, theme, true));
 		layout->set_viewport_size([[self enclosingScrollView] documentVisibleRect].size);
 	}


### PR DESCRIPTION
Currently changing font name/size in one editing window will affect font size in other windows. This patch makes themes immutable which avoids this issue. Also theme styles are now shared.
