### PR TITLE
Correct height of header when tabs above document is enabled

### DIFF
--- a/Frameworks/OakFileBrowser/src/ui/OFBHeaderView.mm
+++ b/Frameworks/OakFileBrowser/src/ui/OFBHeaderView.mm
@@ -86,6 +86,6 @@ static NSPopUpButton* OakCreatePopUpButton ()
 
 - (NSSize)intrinsicContentSize
 {
-	return NSMakeSize(NSViewNoInstrinsicMetric, self.matchTabBarHeight ? 20 : 24);
+	return NSMakeSize(NSViewNoInstrinsicMetric, self.matchTabBarHeight ? 21 : 24);
 }
 @end


### PR DESCRIPTION
Previously this appeared correct because once you clicked the minimum height of the pop-up menu set it to the correct height. Corrects an issue noted by @fatiotus in #728.
