### PR TITLE
If scope selector contains $ only consider document scopes

### DIFF
--- a/Frameworks/parse/src/parse.cc
+++ b/Frameworks/parse/src/parse.cc
@@ -180,7 +180,7 @@ namespace parse
 
 	static scope::scope_t create_scope (scope::scope_t const& current_scope, std::string const& format_string, regexp::match_t const& match)
 	{
-		return current_scope.append(pattern_is_format_string(format_string) ? format_string::expand(format_string, match.captures()) : format_string);
+		return current_scope.append(pattern_is_format_string(format_string) ? format_string::expand(format_string, match.captures()) : format_string, true);
 	}
 
 	static void apply_captures (scope::scope_t scope, regexp::match_t const& m, repository_ptr const& captures, std::map<size_t, scope::scope_t>& res, bool firstLine)

--- a/Frameworks/scope/src/match.cc
+++ b/Frameworks/scope/src/match.cc
@@ -38,14 +38,18 @@ namespace scope
 			ENTER;
 			//printf("scope selector:%s\n", this->to_s().c_str());
 			size_t i = path.scopes.size(); // “source.ruby string.quoted.double constant.character”
+			bool anchor_to_bol = this->anchor_to_bol;
+			if( anchor_to_eol)
+			{
+				while(i && !path.scopes[i-1].document_scope) --i;
+			}
 			const size_t size_i = i;
 			size_t j = scopes.size();      // “string > constant $”
 			const size_t size_j = j;
 			
-			bool anchor_to_bol = this->anchor_to_bol;
 			bool anchor_to_eol = this->anchor_to_eol;
 			//printf("scope selector: anchor_to_bol:%s anchor_to_eol:%s\n", anchor_to_bol?"yes":"no", anchor_to_eol?"yes":"no");
-			
+
 			bool check_next = false;
 			size_t reset_i, reset_j;
 			double reset_score = 0;

--- a/Frameworks/scope/src/scope.cc
+++ b/Frameworks/scope/src/scope.cc
@@ -36,11 +36,12 @@ namespace scope
 		return i == rhsScopes.size();
 	}
 
-	scope_t scope_t::append (std::string const& atom) const
+	scope_t scope_t::append (std::string const& atom, bool document_scope) const
 	{
 		scope_t res;
 		res.path.reset(new types::path_t(path ? *path : types::path_t()));
 		types::scope_t scope;
+		scope.document_scope = document_scope;
 		parse::scope(atom.data(), atom.data() + atom.size(), scope);
 		res.path->scopes.push_back(scope);
 		return res;

--- a/Frameworks/scope/src/scope.h
+++ b/Frameworks/scope/src/scope.h
@@ -25,7 +25,7 @@ namespace scope
 
 		bool has_prefix (scope_t const& rhs) const;
 
-		scope_t append (std::string const& atom) const;
+		scope_t append (std::string const& atom, bool document_scope = false) const;
 		scope_t parent () const;
 
 		bool operator== (scope_t const& rhs) const;

--- a/Frameworks/scope/src/types.h
+++ b/Frameworks/scope/src/types.h
@@ -25,9 +25,10 @@ namespace scope
 
 		struct scope_t
 		{
-			scope_t () : anchor_to_previous(false) { }
+			scope_t () : anchor_to_previous(false), document_scope(true) { }
 			std::vector<atom_t> atoms;
 			bool anchor_to_previous;
+			bool document_scope;
 
 			bool operator== (scope_t const& rhs) const { return atoms == rhs.atoms; }
 			bool operator!= (scope_t const& rhs) const { return atoms != rhs.atoms; }

--- a/Frameworks/scope/tests/t_scope_selector.cc
+++ b/Frameworks/scope/tests/t_scope_selector.cc
@@ -27,6 +27,14 @@ public:
 				
 	}
 
+	void test_dollar ()
+	{
+		scope::scope_t scope("foo bar");
+		scope::scope_t dyn = scope.append("dyn");
+		TS_ASSERT_EQUALS(scope::selector_t("foo bar$").does_match(dyn), true);
+		TS_ASSERT_EQUALS(scope::selector_t("foo bar dyn$").does_match(dyn), false);
+		TS_ASSERT_EQUALS(scope::selector_t("foo bar dyn").does_match(dyn), true);
+	}
 	void test_anchor ()
 	{
 		TS_ASSERT_EQUALS(scope::selector_t("^ foo").does_match("foo bar"), true);


### PR DESCRIPTION
Scope selectors like "source.c$" should match scopes like "source.c attr.something.1 attr.something.2 dyn.selection". This patch changes the scope matching to behave this way.

This is done by separating document scopes from non document scopes.
the method _append_ in _scope_t_ has been changed to take a bool indicating if the scope is a document scope. Strings passed to the various scope constructors still create scopes that are document scopes. e.g.

```
 scope::scope_t("source scope");
```
