### PR TITLE
Improve accessibility of file browser items

### DIFF
--- a/Frameworks/OakFileBrowser/src/FSOutlineViewDelegate.mm
+++ b/Frameworks/OakFileBrowser/src/FSOutlineViewDelegate.mm
@@ -382,7 +382,7 @@ static NSSet* VisibleItems (NSOutlineView* outlineView, FSItem* root, NSMutableS
 	cell.stringValue       = item.name;
 	// cell.textColor         = lstat([[item.url path] fileSystemRepresentation], &(struct stat){ 0 }) == 0 ? [NSColor textColor] : [NSColor redColor];
 	// cell.target            = delegate;
-	// cell.representedObject = item;
+	cell.representedObject = item;
 	if([cell respondsToSelector:@selector(setLabelIndex:)])
 		[cell setLabelIndex:item.labelIndex];
 	if([cell respondsToSelector:@selector(setIsOpen:)])


### PR DESCRIPTION
More info in the commit message as usual.

I guess the main point of discussion here is where the appropriate code belongs - whether or not it is right to set the `representedObject` of `OFBPathInfoCell` to the relevant FSItem and use this info
rmation inside the `OFBPathInfoCell` accessibility support (this is the way I did it as I felt `OFBPathInfoCell` should know its accessibility since it could be used in more than one place, like File C
hooser, which, however, does not seem to reflect this accessibility support as it has its own logic to determine file attributes), or whether to set the accessibility attributes as override values in `
[FSOutlineViewDelegate willDisplayCell:...]`.

These patches are released to public domain by my employer, BRAILCOM,o.p.s.
