### PR TITLE
Post AXValueChanged when changing selected tab

### DIFF
--- a/Frameworks/OakAppKit/src/OakTabBarView.mm
+++ b/Frameworks/OakAppKit/src/OakTabBarView.mm
@@ -721,6 +721,7 @@ static id SafeObjectAtIndex (NSArray* array, NSUInteger index)
 	if(selectedTab == anIndex)
 		return;
 	selectedTab = anIndex;
+	NSAccessibilityPostNotification(self, NSAccessibilityValueChangedNotification);
 	self.layoutNeedsUpdate = YES;
 }
 


### PR DESCRIPTION
When this notification is posted, then VoiceOver reads the name of the new tab being switched to, enabling easier navigation between open tabs.

This patch is released to public domain by my employer, BRAILCOM,o.p.s.
