### PR TITLE
Setup document scope attr.project.lein for Leiningen projects.

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -998,6 +998,7 @@ namespace
 		{ "attr.project.cmake", "CMakeLists.txt", "build", },
 		{ "attr.project.maven", "pom.xml",        "build", },
 		{ "attr.project.scons", "SConstruct",     "build", },
+		{ "attr.project.lein",  "project.clj",    "build", },
 	};
 
 	_externalScopeAttributes.clear();


### PR DESCRIPTION
Leiningen is a build automation and dependency management tool mainly used for Clojure projects.
