### PR TITLE
A few API methods for OakTextView

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.h
+++ b/Frameworks/OakTextView/src/OakTextView.h
@@ -135,4 +135,7 @@ PUBLIC @interface OakTextView : OakView <NSTextInput, NSTextFieldDelegate>
 - (IBAction)saveScratchMacro:(id)sender;
 
 - (void)performBundleItem:(bundles::item_ptr const&)anItem;
+
+- (NSString *)scope;
+- (NSString *)filePath;
 @end

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -1042,6 +1042,25 @@ doScroll:
 	}
 }
 
+- (NSString *)scope
+{
+	if (document) {
+		scope::context_t const& s = [self scopeContext];
+		return [NSString stringWithUTF8String:to_s(s.right).c_str()];
+	}
+
+	return nil;
+}
+
+- (NSString *)filePath
+{
+	if (document && document->path() != NULL_STR) {
+		return [NSString stringWithUTF8String:document->path().c_str()];
+	}
+
+	return nil;
+}
+
 - (void)applicationDidBecomeActiveNotification:(NSNotification*)aNotification
 {
 	citerate(item, bundles::query(bundles::kFieldSemanticClass, "callback.application.did-activate", editor->scope(to_s([self scopeAttributes]))))


### PR DESCRIPTION
I’ve added a few methods to `OakTextView` class: `scope` and `filePath`. These methods are required for some plugins to work properly. Specifically, they are required for my [Emmet](http://emmet.io) plugin.
