### PR TITLE
Add option to show indent guides to the view menu

### DIFF
--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -1154,6 +1154,14 @@
 									<reference key="NSOnImage" ref="944637517"/>
 									<reference key="NSMixedImage" ref="596846250"/>
 								</object>
+								<object class="NSMenuItem" id="911461690">
+									<reference key="NSMenu" ref="377204242"/>
+									<string key="NSTitle">Show Indent Guides</string>
+									<string key="NSKeyEquiv"/>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="944637517"/>
+									<reference key="NSMixedImage" ref="596846250"/>
+								</object>
 								<object class="NSMenuItem" id="1030640146">
 									<reference key="NSMenu" ref="377204242"/>
 									<bool key="NSIsDisabled">YES</bool>
@@ -2461,7 +2469,7 @@
 					<string key="NSFrameSize">{269, 102}</string>
 					<reference key="NSNextKeyView" ref="240907648"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {2560, 1578}}</string>
+				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
 				<string key="NSMinSize">{269, 124}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<string key="NSFrameAutosaveName">Go to Line</string>
@@ -3733,6 +3741,14 @@
 					<int key="connectionID">841</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">toggleShowIndentGuides:</string>
+						<reference key="source" ref="51167417"/>
+						<reference key="destination" ref="911461690"/>
+					</object>
+					<int key="connectionID">843</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
 						<string key="label">bundlesMenuItem</string>
 						<reference key="source" ref="261397727"/>
@@ -4439,6 +4455,7 @@
 							<reference ref="613273090"/>
 							<reference ref="284546527"/>
 							<reference ref="909812697"/>
+							<reference ref="911461690"/>
 						</object>
 						<reference key="parent" ref="412091230"/>
 					</object>
@@ -5637,6 +5654,11 @@
 						<reference key="object" ref="295203618"/>
 						<reference key="parent" ref="1104"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">842</int>
+						<reference key="object" ref="911461690"/>
+						<reference key="parent" ref="377204242"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -5922,6 +5944,7 @@
 					<string>833.IBPluginDependency</string>
 					<string>836.IBPluginDependency</string>
 					<string>839.IBPluginDependency</string>
+					<string>842.IBPluginDependency</string>
 				</object>
 				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -6204,6 +6227,7 @@
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="unlocalizedProperties">
@@ -6218,7 +6242,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">841</int>
+			<int key="maxID">843</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -6715,6 +6739,7 @@
 							<string>toggleOverwriteMode:</string>
 							<string>toggleScrollPastEnd:</string>
 							<string>toggleShowInvisibles:</string>
+							<string>toggleShowIndentGuides:</string>
 							<string>toggleShowWrapColumn:</string>
 							<string>toggleSoftTabs:</string>
 							<string>toggleSoftWrap:</string>
@@ -6722,6 +6747,7 @@
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
@@ -6892,6 +6918,7 @@
 							<string>toggleOverwriteMode:</string>
 							<string>toggleScrollPastEnd:</string>
 							<string>toggleShowInvisibles:</string>
+							<string>toggleShowIndentGuides:</string>
 							<string>toggleShowWrapColumn:</string>
 							<string>toggleSoftTabs:</string>
 							<string>toggleSoftWrap:</string>
@@ -7220,6 +7247,10 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
+								<string key="name">toggleShowIndentGuides:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
 								<string key="name">toggleShowWrapColumn:</string>
 								<string key="candidateClassName">id</string>
 							</object>
@@ -7397,9 +7428,11 @@
 							<string>toggleMacroRecording:</string>
 							<string>toggleScrollPastEnd:</string>
 							<string>toggleShowInvisibles:</string>
+							<string>toggleShowIndentGuides:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
@@ -7414,6 +7447,7 @@
 							<string>toggleMacroRecording:</string>
 							<string>toggleScrollPastEnd:</string>
 							<string>toggleShowInvisibles:</string>
+							<string>toggleShowIndentGuides:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -7431,6 +7465,10 @@
 							</object>
 							<object class="IBActionInfo">
 								<string key="name">toggleShowInvisibles:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">toggleShowIndentGuides:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 						</object>

--- a/Frameworks/OakTextView/src/OakTextView.h
+++ b/Frameworks/OakTextView/src/OakTextView.h
@@ -35,7 +35,7 @@ PUBLIC @interface OakTextView : OakView <NSTextInput, NSTextFieldDelegate>
 	std::string fontName;
 	CGFloat fontSize;
 	BOOL antiAlias;
-	BOOL showInvisibles;
+	char showInvisibles;
 	BOOL scrollPastEnd;
 	ng::editor_ptr editor;
 	std::shared_ptr<ng::layout_t> layout;
@@ -105,7 +105,7 @@ PUBLIC @interface OakTextView : OakView <NSTextInput, NSTextFieldDelegate>
 @property (nonatomic) NSFont*                               font;
 @property (nonatomic) BOOL                                  antiAlias;
 @property (nonatomic) size_t                                tabSize;
-@property (nonatomic) BOOL                                  showInvisibles;
+@property (nonatomic) char                                  showInvisibles;
 @property (nonatomic) BOOL                                  softWrap;
 @property (nonatomic) BOOL                                  scrollPastEnd;
 @property (nonatomic) BOOL                                  softTabs;
@@ -130,6 +130,7 @@ PUBLIC @interface OakTextView : OakView <NSTextInput, NSTextFieldDelegate>
 - (IBAction)toggleMacroRecording:(id)sender;
 - (IBAction)toggleFoldingAtLine:(NSUInteger)lineNumber recursive:(BOOL)flag;
 - (IBAction)toggleShowInvisibles:(id)sender;
+- (IBAction)toggleShowIndentGuides:(id)sender;
 - (IBAction)toggleScrollPastEnd:(id)sender;
 
 - (IBAction)saveScratchMacro:(id)sender;

--- a/Frameworks/layout/src/layout.cc
+++ b/Frameworks/layout/src/layout.cc
@@ -756,7 +756,7 @@ namespace ng
 
 	}
 
-	void layout_t::draw (ng::context_t const& context, CGRect visibleRect, bool isFlipped, bool showInvisibles, ng::ranges_t const& selection, ng::ranges_t const& highlightRanges, bool drawBackground)
+	void layout_t::draw (ng::context_t const& context, CGRect visibleRect, bool isFlipped, char showInvisibles, ng::ranges_t const& selection, ng::ranges_t const& highlightRanges, bool drawBackground)
 	{
 		update_metrics(visibleRect);
 

--- a/Frameworks/layout/src/layout.h
+++ b/Frameworks/layout/src/layout.h
@@ -64,7 +64,7 @@ namespace ng
 
 		// ======================
 
-		void draw (ng::context_t const& context, CGRect rectangle, bool isFlipped, bool showInvisibles, ng::ranges_t const& selection, ng::ranges_t const& highlightRanges = ng::ranges_t(), bool drawBackground = true);
+		void draw (ng::context_t const& context, CGRect rectangle, bool isFlipped, char showInvisibles, ng::ranges_t const& selection, ng::ranges_t const& highlightRanges = ng::ranges_t(), bool drawBackground = true);
 		ng::index_t index_at_point (CGPoint point) const;
 		CGRect rect_at_index (ng::index_t const& index) const;
 		CGRect rect_for_range (size_t first, size_t last) const;

--- a/Frameworks/layout/src/paragraph.cc
+++ b/Frameworks/layout/src/paragraph.cc
@@ -160,7 +160,7 @@ namespace ng
 			_width += tabWidth;
 	}
 
-	void paragraph_t::node_t::draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const
+	void paragraph_t::node_t::draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const
 	{
 		if(_line)
 			_line->draw_background(CGPointMake(anchor.x, anchor.y), lineHeight, context, isFlipped, backgroundColor);
@@ -185,7 +185,7 @@ namespace ng
 		}
 	}
 
-	void paragraph_t::node_t::draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const
+	void paragraph_t::node_t::draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const
 	{
 		if(_line)
 			_line->draw_foreground(CGPointMake(anchor.x, anchor.y + baseline), context, isFlipped, misspelled);
@@ -197,12 +197,15 @@ namespace ng
 			switch(_type)
 			{
 				case kNodeTypeTab:
-					str = "‣";
+					str = showInvisibles & TextInvisiblesIndentGuide ? "┊" : "‣";
 					scope = scope.append("deco.invisible.tab");
 				break;
 				case kNodeTypeNewline:
-					str = "¬";
-					scope = scope.append("deco.invisible.newline");
+					if(showInvisibles & TextInvisiblesShow)
+					{
+							str = "¬";
+							scope = scope.append("deco.invisible.newline");
+					}
 				break;
 			}
 
@@ -681,7 +684,7 @@ namespace ng
 		return index;
 	}
 
-	void paragraph_t::draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const
+	void paragraph_t::draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const
 	{
 		auto lines = softlines(metrics);
 		for(size_t i = 0; i < lines.size(); ++i)
@@ -697,7 +700,7 @@ namespace ng
 		}
 	}
 
-	void paragraph_t::draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const
+	void paragraph_t::draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const
 	{
 		CGContextSetTextMatrix(context, CGAffineTransformMake(1, 0, 0, 1, 0, 0));
 

--- a/Frameworks/layout/src/paragraph.h
+++ b/Frameworks/layout/src/paragraph.h
@@ -7,6 +7,10 @@
 #include <theme/theme.h>
 #include <oak/misc.h>
 
+
+#define TextInvisiblesShow 0x1
+#define TextInvisiblesIndentGuide 0x2
+
 namespace ng
 {
 	struct line_t;
@@ -32,8 +36,8 @@ namespace ng
 		void did_update_scopes (size_t from, size_t to, ng::buffer_t const& buffer, size_t bufferOffset);
 		bool layout (theme_ptr const& theme, bool softWrap, size_t wrapColumn, ct::metrics_t const& metrics, CGRect visibleRect, ng::buffer_t const& buffer, size_t bufferOffset);
 
-		void draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
-		void draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const;
+		void draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
+		void draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const;
 
 		ng::index_t index_at_point (CGPoint point, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
 		CGRect rect_at_index (ng::index_t const& index, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
@@ -68,8 +72,8 @@ namespace ng
 
 			void layout (CGFloat x, CGFloat tabWidth, theme_ptr const& theme, bool softWrap, size_t wrapColumn, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, std::string const& fillStr);
 			void reset_font_metrics (ct::metrics_t const& metrics);
-			void draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const;
-			void draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const;
+			void draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const;
+			void draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, char showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const;
 
 			node_type_t type () const                      { return _type; }
 			size_t length () const                         { return _length; }


### PR DESCRIPTION
This adds a "Show Indent Guides" option in the view menu that shows indent guides regardless of the value of the Show Invisibles option.
#197 #168
