### PR TITLE
Extended OakTextView API

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.h
+++ b/Frameworks/OakTextView/src/OakTextView.h
@@ -135,4 +135,6 @@ PUBLIC @interface OakTextView : OakView <NSTextInput, NSTextFieldDelegate>
 - (IBAction)saveScratchMacro:(id)sender;
 
 - (void)performBundleItem:(bundles::item_ptr const&)anItem;
+
+- (NSString*)scopeAsString;
 @end

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -1042,6 +1042,11 @@ doScroll:
 	}
 }
 
+- (NSString*)scopeAsString
+{
+	return [NSString stringWithCxxString:to_s([self scopeContext].right)];
+}
+
 - (void)applicationDidBecomeActiveNotification:(NSNotification*)aNotification
 {
 	citerate(item, bundles::query(bundles::kFieldSemanticClass, "callback.application.did-activate", editor->scope(to_s([self scopeAttributes]))))


### PR DESCRIPTION
Added `scopeAsString` method to retrieve current scope as NSString

(A follow-up to previous pull request: https://github.com/textmate/textmate/pull/944)
