### PR TITLE
Use left/right filter in scope selector as high/low injection priority marker

### DIFF
--- a/Frameworks/parse/src/parse.cc
+++ b/Frameworks/parse/src/parse.cc
@@ -294,6 +294,27 @@ namespace parse
 		return rank;
 	}
 
+	static void collect_injections (rule_ptr const& base, char const* first, char const* last, stack_ptr const& stack, size_t i, bool firstLine, std::set<ranked_match_t>& res, std::map<size_t, regexp::match_t>& match_cache, std::set<size_t>& unique, size_t rank, scope::context_t const& scope)
+	{
+		for(stack_ptr node = stack; node; node = node->parent)
+		{
+			if(!node->rule->injections)
+				continue;
+
+			iterate(it, *node->rule->injections)
+			{
+				if(scope::selector_t(it->first).does_match(scope))
+					collect_rule(base, first, last, stack->anchor, i, firstLine, it->second, res, match_cache, unique, rank);
+			}
+		}
+		
+		citerate(it, injected_grammars())
+		{
+			if(it->first.does_match(scope))
+				collect_children(base, first, last, stack->anchor, i, firstLine, it->second->children, res, match_cache, unique, rank);
+		}
+	}
+
 	static void collect_rules (rule_ptr const& base, char const* first, char const* last, size_t i, bool firstLine, stack_ptr const& stack, std::set<ranked_match_t>& res, std::map<size_t, regexp::match_t>& match_cache)
 	{
 		res.clear();
@@ -306,25 +327,14 @@ namespace parse
 		}
 
 		std::set<size_t> unique;
-		size_t rank = collect_children(base, first, last, stack->anchor, i, firstLine, stack->rule->children, res, match_cache, unique);
+		size_t rank = 0;
+		auto context = scope::context_t(stack->scope, "");
+		collect_injections(base, first, last, stack, i, firstLine, res, match_cache, unique, rank, context);
 
-		for(stack_ptr node = stack; node; node = node->parent)
-		{
-			if(!node->rule->injections)
-				continue;
+		collect_children(base, first, last, stack->anchor, i, firstLine, stack->rule->children, res, match_cache, unique, rank);
 
-			iterate(it, *node->rule->injections)
-			{
-				if(it->first == "." || scope::selector_t(it->first).does_match(stack->scope))
-					collect_rule(base, first, last, stack->anchor, i, firstLine, it->second, res, match_cache, unique, rank);
-			}
-		}
-
-		citerate(it, injected_grammars())
-		{
-			if(to_s(it->first) == "." || it->first.does_match(stack->scope))
-				collect_children(base, first, last, stack->anchor, i, firstLine, it->second->children, res, match_cache, unique, rank);
-		}
+		context = scope::context_t("", stack->scope);
+		collect_injections(base, first, last, stack, i, firstLine, res, match_cache, unique, rank, context);
 	}
 
 	static bool has_cycle (size_t rule_id, size_t i, stack_ptr const& stack)


### PR DESCRIPTION
Using a left filter (e.g "L:(source.c meta.function.c)") will insert matched injections before other rules are matched. Using no filter or a right filter keeps the old behavior and matches after other rules. 
