### PR TITLE
Added common dot files to default includes.

### DIFF
--- a/Applications/TextMate/resources/Default.tmProperties
+++ b/Applications/TextMate/resources/Default.tmProperties
@@ -4,7 +4,7 @@ fontSize = 12
 encoding = "UTF-8"
 
 exclude  = "{*.{o,pyc},Icon\r,CVS,_darcs,_MTN,\{arch\},blib,*~.nib}"
-include  = "{*,.tm_properties,.htaccess}"
+include  = "{*,.tm_properties,.htaccess,.gitignore,.env,.ruby-version}"
 binary   = "{*.{ai,gif,icns,ico,jpg,jpeg,m4v,nib,o,pdf,png,psd,pyc,rtf,scssc,tif,tiff,xib},Icon\r}"
 
 windowTitleSCM     = '${TM_SCM_BRANCH:+ ($TM_SCM_NAME: $TM_SCM_BRANCH)}'


### PR DESCRIPTION
`.gitignore` doesn't need explanation.

`.env` for common dotenv libraries for multiple languages/frameworks (mainly for the web development where you've got different local/remote environments).

`.ruby-version` is commonly used, recommended ruby version chooser for `rbenv`/`rvm`.
