### PR TITLE
Appearance tweaks

### DIFF
--- a/Frameworks/HTMLOutput/src/browser/HOStatusBar.mm
+++ b/Frameworks/HTMLOutput/src/browser/HOStatusBar.mm
@@ -114,7 +114,7 @@ static NSTextField* OakCreateTextField ()
 	};
 
 	NSArray* layout = @[
-		@"H:|-(8)-[back(==22)]-(2)-[forward(==back)]-(7)-[divider]",
+		@"H:|-(3)-[back(==22)]-(2)-[forward(==back)]-(2)-[divider]",
 		@"V:|[back(==forward,==divider)]|",
 		@"V:[status]-5-|",
 	];

--- a/Frameworks/OakFileBrowser/src/ui/OFBActionsView.mm
+++ b/Frameworks/OakFileBrowser/src/ui/OFBActionsView.mm
@@ -94,7 +94,7 @@ static NSPopUpButton* OakCreateActionPopUpButton ()
 			[self addSubview:view];
 		}
 
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-9-[create(==22)]-1-[divider]-4-[actions(==30)]-(>=8)-[reload(==22,==search,==favorites,==scm)][search]-1-[favorites]-2-[scm]-(12)-|" options:0 metrics:nil views:views]];
+		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-3-[create(==24)]-1-[divider]-5-[actions(==30)]-(>=8)-[reload(==22,==search,==favorites,==scm)][search]-1-[favorites]-2-[scm]-(12)-|" options:0 metrics:nil views:views]];
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[create(==divider,==actions,==reload,==search,==favorites,==scm)]|"                                                                   options:0 metrics:nil views:views]];
 	}
 	return self;

--- a/Frameworks/OakTextView/src/OTVStatusBar.mm
+++ b/Frameworks/OakTextView/src/OTVStatusBar.mm
@@ -134,7 +134,7 @@ static NSButton* OakCreateImageToggleButton (NSImage* image)
 		[self.symbolPopUp setContentHuggingPriority:NSLayoutPriorityDefaultLow-1 forOrientation:NSLayoutConstraintOrientationHorizontal];
 		[self.symbolPopUp setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow-1 forOrientation:NSLayoutConstraintOrientationHorizontal];
 		
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-16-[line]-[selection(>=50,<=225)]-8-[dividerOne]-(-3)-[grammar(>=125,<=225)]-5-[dividerTwo]-(-3)-[tabSize(<=102)]-4-[dividerThree]-4-[items(==30)]-4-[dividerFour]-(-3)-[symbol(>=125)]-5-[dividerFive]-5-[recording]-14-|" options:0 metrics:nil views:views]];
+		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-10-[line]-[selection(>=50,<=225)]-8-[dividerOne]-(-2)-[grammar(>=125,<=225)]-5-[dividerTwo]-(-2)-[tabSize(<=102)]-4-[dividerThree]-5-[items(==30)]-4-[dividerFour]-(-2)-[symbol(>=125)]-5-[dividerFive]-6-[recording]-7-|" options:0 metrics:nil views:views]];
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[line]-5-|" options:0 metrics:nil views:views]];
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[selection]-5-|" options:0 metrics:nil views:views]];
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[grammar(==dividerOne,==dividerTwo,==dividerThree,==dividerFour,==dividerFive,==items,==tabSize,==symbol,==recording)]|" options:0 metrics:nil views:views]];


### PR DESCRIPTION
Some appearance tweaks I made a while ago, now in a separate pull request so they can be more thoroughly discussed.

See some old discussion at https://github.com/textmate/textmate/pull/914

Old:
![screen shot 2013-06-30 at 1 43 43 pm](https://f.cloud.github.com/assets/14237/728220/9f5d2ffa-e1f4-11e2-99e2-c24df4ee7cfb.png)

Cursor tracking rectangles:
![screen shot 2013-06-30 at 1 43 31 pm](https://f.cloud.github.com/assets/14237/728215/7dbaa990-e1f4-11e2-8b0d-610e3b45d36e.png)

New:

![screen shot 2013-06-30 at 7 17 55 pm](https://f.cloud.github.com/assets/14237/728222/a630dc78-e1f4-11e2-9953-d056759526a4.png)
![screen shot 2013-06-30 at 7 17 30 pm](https://f.cloud.github.com/assets/14237/728221/a3e2a4b0-e1f4-11e2-9d56-39be8083e26a.png)

Note: the corner-resize tracking rects are slightly overlapping the buttons, however if you click without dragging, the click **will** go through to the button — i.e., the only thing that is affected is the cursor, which looks like a resize handle when it's over the corner.
