### PR TITLE
Let OakFinderLabelChooser draw and manage it's own title

### DIFF
--- a/Frameworks/OakAppKit/src/OakFinderLabelChooser.h
+++ b/Frameworks/OakAppKit/src/OakFinderLabelChooser.h
@@ -5,4 +5,5 @@ PUBLIC @interface OakFinderLabelChooser : NSView
 @property (nonatomic) NSInteger selectedIndex;
 @property (nonatomic, weak) id target;
 @property (nonatomic) SEL action;
+@property (nonatomic) NSFont* font;
 @end

--- a/Frameworks/OakAppKit/src/OakFinderLabelChooser.mm
+++ b/Frameworks/OakAppKit/src/OakFinderLabelChooser.mm
@@ -21,6 +21,7 @@ static const CGFloat LabelNameHeight = 15;
 {
 	if(self = [super initWithFrame:rect])
 	{
+		self.font             = [NSFont systemFontOfSize:14];
 		self.enabled          = YES;
 		self.highlightedIndex = -1;
 	}
@@ -89,6 +90,14 @@ static const CGFloat LabelNameHeight = 15;
 		{ { 252, 162, 154}, { 251, 100,  91} }, // Red
 		{ { 249, 206, 143}, { 246, 170,  68} }, // Orange
 	};
+
+	NSMutableDictionary* titleAttributes;
+	titleAttributes = [NSMutableDictionary dictionary];
+	[titleAttributes setObject:[NSFont menuFontOfSize:self.font.pointSize] forKey:NSFontAttributeName];
+	if(!self.enabled)
+		[titleAttributes setObject:[NSColor grayColor] forKey:NSForegroundColorAttributeName];
+
+	[@"Label:" drawInRect:NSInsetRect(rect, 22, 0) withAttributes:titleAttributes];
 
 	for(NSInteger i = 0; i < 8; ++i)
 	{

--- a/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
+++ b/Frameworks/OakFileBrowser/src/OakFileBrowser.mm
@@ -956,13 +956,13 @@ static NSMutableSet* SymmetricDifference (NSMutableSet* aSet, NSMutableSet* anot
 
 	if(hasFileSelected)
 	{
-		OakFinderLabelChooser* swatch = [[OakFinderLabelChooser alloc] initWithFrame:NSMakeRect(0, 0, 166, 37)];
+		OakFinderLabelChooser* swatch = [[OakFinderLabelChooser alloc] initWithFrame:NSMakeRect(0, 0, 166, 55)];
 		swatch.selectedIndex = [[selectedItems lastObject] labelIndex];
 		swatch.action        = @selector(changeColor:);
 		swatch.target        = self;
+		swatch.font          = [aMenu font];
 
 		[aMenu addItem:[NSMenuItem separatorItem]];
-		[aMenu addItemWithTitle:@"Label:" action:@selector(nop:) keyEquivalent:@""];
 		[[aMenu addItemWithTitle:@"Color Swatch" action:@selector(nop:) keyEquivalent:@""] setView:swatch];
 	}
 


### PR DESCRIPTION
This removes the need to create and manage a separate menu item
as a placeholder for the title of the color swatch in the file
browser action menu.
