### PR TITLE
Support text attributes with VoiceOver

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -1178,7 +1178,7 @@ doScroll:
 		std::map<size_t, bool> misspellings = document->buffer().misspellings(from, to);
 		auto pair = misspellings.begin();
 		auto const end = misspellings.end();
-		ASSERT(pair->second);
+		ASSERT((pair == end) || pair->second);
 		runRange = NSMakeRange(0, 0);
 		if (pair != end)
 			runRange.length = utf16::distance(text.data(), text.data() + pair->first);


### PR DESCRIPTION
VoiceOver can announce text formatting, such as bold font, italics,
underline, font, etc., as well as whether text is misspelled. For this, it
needs the AXAttributedStringForRange attribute supported. This commit does
exactly that.

Testing can be done in this way (VO stands for Ctrl-Option):
- first interact with the text (VO-Shift-down arrow when standing
  on the text element)
- to announce text attributes for character after cursor, press VO-T
- to seek for next:
  - misspelled text: VO-Cmd-E
  - color change:    VO-Cmd-K
  - underlined text: VO-Cmd-U
  - many more (see VO-H-H, "Find", close help with Esc)
- to seek for previous *: just add Shift to the shortcut

Some attributes remain to be supported (full list of attributes is
available at:
https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSAccessibility_Protocol/Reference/Reference.html#//apple_ref/doc/uid/20000945-SW53).

The misspelled text VoiceOver support can be used nicely with TextMate's
spelling support:
1. the user finds next mistake with VO-Cmd-E, hears the misspelled word,
   perhaps reads it on a braille display
2. the user then presses Cmd-; to show the spelling menu for that word
   and chooses the desired resolution (apply suggested correction etc.)
3. go back to step 1. :-)

Also the user can turn on announcements of attribute changes:
- press VO-V
- choose "Text Attributes" setting with arrow left/right
- choose "Play Tone" or "Speak" with arrow up/down and confirm with Return

Then when moving in the text with arrows (e.g. arrow down), VoiceOver beeps
(or speaks text attributes) whenever text attributes change.
