### PR TITLE
Extend invisibles

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -62,6 +62,7 @@ struct buffer_refresh_callback_t;
 	theme_ptr theme;
 	std::string fontName;
 	CGFloat fontSize;
+	std::string invisibles;
 	ng::editor_ptr editor;
 	std::shared_ptr<ng::layout_t> layout;
 	NSUInteger refreshNestCount;
@@ -496,6 +497,7 @@ static std::string shell_quote (std::vector<std::string> paths)
 		editor = ng::editor_for_document(document);
 		wrapColumn = settings.get(kSettingsWrapColumnKey, wrapColumn);
 		layout = std::make_shared<ng::layout_t>(document->buffer(), theme, settings.get(kSettingsSoftWrapKey, false), self.scrollPastEnd, wrapColumn, document->folded());
+		layout->set_invisibles(invisibles);
 		if(settings.get(kSettingsShowWrapColumnKey, false))
 			layout->set_draw_wrap_column(true);
 
@@ -555,6 +557,7 @@ static std::string shell_quote (std::vector<std::string> paths)
 		theme          = parse_theme(bundles::lookup(settings.get(kSettingsThemeKey, NULL_STR)));
 		fontName       = settings.get(kSettingsFontNameKey, NULL_STR);
 		fontSize       = settings.get(kSettingsFontSizeKey, 11);
+		invisibles     = settings.get(kSettingsInvisiblesKey, NULL_STR);
 		theme          = theme->copy_with_font_name_and_size(fontName, fontSize);
 
 		_showInvisibles = settings.get(kSettingsShowInvisiblesKey, false);

--- a/Frameworks/layout/src/ct.h
+++ b/Frameworks/layout/src/ct.h
@@ -20,6 +20,14 @@ namespace ng
 		std::function<CGImageRef(double, double)> _folding_dots_create;
 		mutable std::map<std::pair<double, double>, CGImageRef> _folding_dots_cache;
 	};
+	
+	struct invisibles_t
+	{
+		bool show;
+		std::string tab;
+		std::string space;
+		std::string newline;
+	};
 
 } /* ng */
 

--- a/Frameworks/layout/src/layout.cc
+++ b/Frameworks/layout/src/layout.cc
@@ -98,6 +98,45 @@ namespace ng
 		clear_text_widths();
 	}
 
+	void layout_t::set_invisibles (std::string const& invisibles)
+	{
+		int i;
+		int len = invisibles.length();
+		std::string *current_string = NULL;
+		for (i=0;i<len;++i)
+		{
+			switch(invisibles[i])
+			{
+				case '\t':
+					_invisibles.tab = "";
+					if (i > 0 && invisibles[i-1] == '~') {
+						current_string = NULL;
+					} else {
+						current_string = &_invisibles.tab;
+					}
+				break;
+				case ' ':
+					_invisibles.space = "";
+					if (i > 0 && invisibles[i-1] == '~') {
+						current_string = NULL;
+					} else {
+						current_string = &_invisibles.space;
+					}
+					break;
+				case '\n':
+					_invisibles.newline = "";
+					if (i > 0 && invisibles[i-1] == '~') {
+						current_string = NULL;
+					} else {
+						current_string = &_invisibles.newline;
+					}
+				break;
+			}
+			if(i < len-1 && current_string && invisibles[i+1] != '~')
+				current_string->append(invisibles,i+1,1);
+		}
+	}
+
 	void layout_t::set_tab_size (size_t tabSize)
 	{
 		if(tabSize == _tab_size)
@@ -794,6 +833,8 @@ namespace ng
 
 		CGContextSetTextMatrix(context, CGAffineTransformMake(1, 0, 0, 1, 0, 0));
 
+		_invisibles.show = showInvisibles;
+
 		CGColorRef background = _theme->background(scope::to_s(_buffer.scope(0).left));
 		if(drawBackground)
 			render::fill_rect(context, background, visibleRect);
@@ -808,7 +849,7 @@ namespace ng
 		if(drawBackground)
 		{
 			foreach(row, firstY, _rows.lower_bound(yMax, &row_y_comp))
-				row->value.draw_background(_theme, *_metrics, context, isFlipped, visibleRect, showInvisibles, background, _buffer, row->offset._length, CGPointMake(_margin.left, _margin.top + row->offset._height));
+				row->value.draw_background(_theme, *_metrics, context, isFlipped, visibleRect, _invisibles, background, _buffer, row->offset._length, CGPointMake(_margin.left, _margin.top + row->offset._height));
 		}
 
 		base_colors_t const& baseColors = get_base_colors(_theme->is_dark());
@@ -836,7 +877,7 @@ namespace ng
 		}
 
 		foreach(row, firstY, _rows.lower_bound(yMax, &row_y_comp))
-			row->value.draw_foreground(_theme, *_metrics, context, isFlipped, visibleRect, showInvisibles, _buffer, row->offset._length, selection, CGPointMake(_margin.left, _margin.top + row->offset._height));
+			row->value.draw_foreground(_theme, *_metrics, context, isFlipped, visibleRect, _invisibles, _buffer, row->offset._length, selection, CGPointMake(_margin.left, _margin.top + row->offset._height));
 
 		if(_draw_caret && !_drop_marker)
 		{

--- a/Frameworks/layout/src/layout.h
+++ b/Frameworks/layout/src/layout.h
@@ -37,6 +37,7 @@ namespace ng
 
 		void set_theme (theme_ptr const& theme);
 		void set_font (std::string const& fontName, CGFloat fontSize);
+		void set_invisibles (std::string const& newInvisibles);
 		void set_margin (margin_t const& margin);
 		void set_wrapping (bool softWrap, size_t wrapColumn);
 		void set_scroll_past_end (bool scrollPastEnd);
@@ -171,6 +172,7 @@ namespace ng
 		size_t             _wrap_column;
 		margin_t           _margin;
 		CGSize             _viewport_size = CGSizeZero;
+		invisibles_t       _invisibles = {true, "‣", "·", "¬"};
 
 		bool               _is_key = false;
 		bool               _draw_caret = false;

--- a/Frameworks/layout/src/paragraph.cc
+++ b/Frameworks/layout/src/paragraph.cc
@@ -160,7 +160,7 @@ namespace ng
 			_width += tabWidth;
 	}
 
-	void paragraph_t::node_t::draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const
+	void paragraph_t::node_t::draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const
 	{
 		if(_line)
 			_line->draw_background(CGPointMake(anchor.x, anchor.y), lineHeight, context, isFlipped, backgroundColor);
@@ -185,27 +185,27 @@ namespace ng
 		}
 	}
 
-	void paragraph_t::node_t::draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const
+	void paragraph_t::node_t::draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const
 	{
 		if(_line)
 			_line->draw_foreground(CGPointMake(anchor.x, anchor.y + baseline), context, isFlipped, misspelled);
 
-		if(showInvisibles || (_type != kNodeTypeTab && _type != kNodeTypeNewline && _type != kNodeTypeSpace))
+		if(invisibles.show || (_type != kNodeTypeTab && _type != kNodeTypeNewline && _type != kNodeTypeSpace))
 		{
 			std::string str = NULL_STR;
 			scope::scope_t scope = buffer.scope(bufferOffset).right;
 			switch(_type)
 			{
 				case kNodeTypeTab:
-					str = "‣";
+					str = invisibles.tab;
 					scope.push_scope("deco.invisible.tab");
 				break;
 				case kNodeTypeSpace:
-					str = "·";
+					str = invisibles.space;
 					scope.push_scope("deco.invisible.space");
 				break;
 				case kNodeTypeNewline:
-					str = "¬";
+					str = invisibles.newline;
 					scope.push_scope("deco.invisible.newline");
 				break;
 				case kNodeTypeFolding:
@@ -695,7 +695,7 @@ namespace ng
 		return index;
 	}
 
-	void paragraph_t::draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const
+	void paragraph_t::draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const
 	{
 		auto lines = softlines(metrics);
 		for(size_t i = 0; i < lines.size(); ++i)
@@ -704,14 +704,14 @@ namespace ng
 			size_t offset = lines[i].offset;
 			foreach(node, _nodes.begin() + lines[i].first, _nodes.begin() + lines[i].last)
 			{
-				node->draw_background(theme, context, isFlipped, visibleRect, showInvisibles, backgroundColor, buffer, bufferOffset + offset, CGPointMake(anchor.x + x, anchor.y + lines[i].y), lines[i].height);
+				node->draw_background(theme, context, isFlipped, visibleRect, invisibles, backgroundColor, buffer, bufferOffset + offset, CGPointMake(anchor.x + x, anchor.y + lines[i].y), lines[i].height);
 				x += node->width();
 				offset += node->length();
 			}
 		}
 	}
 
-	void paragraph_t::draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const
+	void paragraph_t::draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const
 	{
 		CGContextSetTextMatrix(context, CGAffineTransformMake(1, 0, 0, 1, 0, 0));
 
@@ -743,7 +743,7 @@ namespace ng
 					}
 				}
 
-				node->draw_foreground(theme, context, isFlipped, visibleRect, showInvisibles, buffer, offset, misspelled, CGPointMake(anchor.x + x, anchor.y + lines[i].y), lines[i].baseline);
+				node->draw_foreground(theme, context, isFlipped, visibleRect, invisibles, buffer, offset, misspelled, CGPointMake(anchor.x + x, anchor.y + lines[i].y), lines[i].baseline);
 				x += node->width();
 				offset += node->length();
 			}

--- a/Frameworks/layout/src/paragraph.h
+++ b/Frameworks/layout/src/paragraph.h
@@ -32,8 +32,8 @@ namespace ng
 		void did_update_scopes (size_t from, size_t to, ng::buffer_t const& buffer, size_t bufferOffset);
 		bool layout (theme_ptr const& theme, bool softWrap, size_t wrapColumn, ct::metrics_t const& metrics, CGRect visibleRect, ng::buffer_t const& buffer, size_t bufferOffset);
 
-		void draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
-		void draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const;
+		void draw_background (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
+		void draw_foreground (theme_ptr const& theme, ct::metrics_t const& metrics, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, ng::buffer_t const& buffer, size_t bufferOffset, ng::ranges_t const& selection, CGPoint anchor) const;
 
 		ng::index_t index_at_point (CGPoint point, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
 		CGRect rect_at_index (ng::index_t const& index, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor) const;
@@ -68,8 +68,8 @@ namespace ng
 
 			void layout (CGFloat x, CGFloat tabWidth, theme_ptr const& theme, bool softWrap, size_t wrapColumn, ct::metrics_t const& metrics, ng::buffer_t const& buffer, size_t bufferOffset, std::string const& fillStr);
 			void reset_font_metrics (ct::metrics_t const& metrics);
-			void draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const;
-			void draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, bool showInvisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const;
+			void draw_background (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, CGColorRef backgroundColor, ng::buffer_t const& buffer, size_t bufferOffset, CGPoint anchor, CGFloat lineHeight) const;
+			void draw_foreground (theme_ptr const& theme, ng::context_t const& context, bool isFlipped, CGRect visibleRect, ng::invisibles_t invisibles, ng::buffer_t const& buffer, size_t bufferOffset, std::vector< std::pair<size_t, size_t> > const& misspelled, CGPoint anchor, CGFloat baseline) const;
 
 			node_type_t type () const                      { return _type; }
 			size_t length () const                         { return _length; }

--- a/Frameworks/settings/src/keys.cc
+++ b/Frameworks/settings/src/keys.cc
@@ -16,6 +16,7 @@ std::string const kSettingsSoftWrapKey                    = "softWrap";
 std::string const kSettingsWrapColumnKey                  = "wrapColumn";
 std::string const kSettingsShowWrapColumnKey              = "showWrapColumn";
 std::string const kSettingsShowInvisiblesKey              = "showInvisibles";
+std::string const kSettingsInvisiblesKey                  = "invisibles";
 
 std::string const kSettingsProjectDirectoryKey            = "projectDirectory";
 std::string const kSettingsSCMStatusKey                   = "scmStatus";

--- a/Frameworks/settings/src/keys.h
+++ b/Frameworks/settings/src/keys.h
@@ -19,6 +19,7 @@ PUBLIC extern std::string const kSettingsSoftWrapKey;
 PUBLIC extern std::string const kSettingsWrapColumnKey;
 PUBLIC extern std::string const kSettingsShowWrapColumnKey;
 PUBLIC extern std::string const kSettingsShowInvisiblesKey;
+PUBLIC extern std::string const kSettingsInvisiblesKey;
 
 PUBLIC extern std::string const kSettingsProjectDirectoryKey;
 PUBLIC extern std::string const kSettingsSCMStatusKey;


### PR DESCRIPTION
This code does two things, first it adds spaces as an invisible rendered by a "·". Second, it adds a property "invisibles" in the .tm_properties file that allows for changing which invisibles are shown and what glyph is used for each.

Invisibles are '\t', '\n', and ' ', to turn one off, add ~[\t \n] to
the settings string. To set the glyph used for the invisible, add [\t
\n][glyph_to_use].

For example, I have been using:
invisibles = "~ \t┊"
This turns off spaces, uses a "┊" for tabs, and leaves newlines at their default.

This is public domain
