### PR TITLE
Keep last effective tab sticky when closing tabs

### DIFF
--- a/Frameworks/OakAppKit/src/OakTabBarView.mm
+++ b/Frameworks/OakAppKit/src/OakTabBarView.mm
@@ -318,6 +318,7 @@ static id SafeObjectAtIndex (NSArray* array, NSUInteger index)
 	NSUInteger selectedTab;
 	NSUInteger hiddenTab;
 	NSUInteger previousShowAsLastTab;
+	NSUInteger previousTabTitlesCount;
 
 	layout_metrics_ptr metrics;
 	std::vector<NSRect> tabRects;
@@ -636,12 +637,16 @@ static id SafeObjectAtIndex (NSArray* array, NSUInteger index)
 	// ==========
 	NSUInteger lastVisibleTab = numberOfTabs > 1 ? numberOfTabs-1 : 0;
 
+	if(previousTabTitlesCount > tabTitles.count && previousTabTitlesCount > numberOfTabs)
+		previousShowAsLastTab -= 1;
+
 	NSUInteger showAsLastTab = lastVisibleTab;
 	if(lastVisibleTab <= selectedTab)
 		showAsLastTab = selectedTab;
 	else if(lastVisibleTab < previousShowAsLastTab)
 		showAsLastTab = previousShowAsLastTab;
-	previousShowAsLastTab = showAsLastTab == lastVisibleTab ? 0 : showAsLastTab;
+	previousShowAsLastTab = showAsLastTab < lastVisibleTab ? 0 : showAsLastTab;	
+	previousTabTitlesCount = tabTitles.count;
 
 	for(NSUInteger tabIndex = 0; tabIndex < tabTitles.count; ++tabIndex)
 	{


### PR DESCRIPTION
When the last effective tab is sticky, closing a tab (after switching to another tab) would cause the next tab in the overflow menu to become sticky.

This also addresses a couple of cases where the effective tab would not be rendered (e.g., closing a tab when the last tab in the overflow menu is sticky).
