### PR TITLE
Allow the up/down cursor keys to wrap to the top or bottom of the list.

### DIFF
--- a/Frameworks/OakFilterList/src/ui/TableView.mm
+++ b/Frameworks/OakFilterList/src/ui/TableView.mm
@@ -17,7 +17,12 @@
 	{
 		if(_tableView.allowsMultipleSelection == NO)
 			extend = NO;
-		NSInteger row = oak::cap((NSInteger)0, [_tableView selectedRow] + anOffset, [_tableView numberOfRows] - 1);
+
+		// let the selection wrap
+		NSInteger row = [_tableView selectedRow] + anOffset;
+		if (row < 0) row = [_tableView numberOfRows] - 1;
+		else if (row > [_tableView numberOfRows] - 1) row = (NSInteger)0;
+
 		[_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:extend];
 		[_tableView scrollRowToVisible:row];
 	}


### PR DESCRIPTION
I find it useful to allow the up/down cursor keys to wrap around the OakFilterList. Anyone else have a use for it? Please consider this patch public domain.

![textmate_file_cursor_wrap](https://f.cloud.github.com/assets/6807/1489069/b6509a24-4763-11e3-8f0a-1c162a4cffb3.gif)
