### PR TITLE
Fix file browser height for tabs above document

### DIFF
--- a/Frameworks/OakAppKit/src/OakUIConstructionFunctions.mm
+++ b/Frameworks/OakAppKit/src/OakUIConstructionFunctions.mm
@@ -177,5 +177,6 @@ NSImageView* OakCreateDividerImageView ()
 	NSImageView* res = [[NSImageView alloc] initWithFrame:NSZeroRect];
 	[res setImage:[NSImage imageNamed:@"Divider" inSameBundleAsClass:[OakDividerLineView class]]];
 	[res setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+	[res setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow forOrientation:NSLayoutConstraintOrientationVertical];
 	return res;
 }


### PR DESCRIPTION
This fixes regression caused by 1de5d90475788143655a60fdbff654139fec3cb4 that
divider height and default compression priority disallowed expected height.

Before:
![zrzut ekranu 2014-01-08 o 12 40 34](https://f.cloud.github.com/assets/103067/1867821/c73afc5e-7859-11e3-8408-63b689cd7601.png)

After:
![zrzut ekranu 2014-01-08 o 12 40 56](https://f.cloud.github.com/assets/103067/1867823/d06150a8-7859-11e3-9332-9d6bdbc2056b.png)
