### PR TITLE
hack in support for overriding the default system provided folder icon

### DIFF
--- a/Frameworks/OakAppKit/src/OakFileIconImage.mm
+++ b/Frameworks/OakAppKit/src/OakFileIconImage.mm
@@ -129,12 +129,24 @@ static NSImage* BadgeForSCMStatus (scm::status::type scmStatus)
 
 			if(res.count == 0)
 			{
+				NSBundle *mainBundle = [NSBundle mainBundle];
+				NSString *file = [mainBundle pathForResource: @"CustomFolder" ofType: @"icns"];
+				BOOL customFolderIconExists = [[NSFileManager defaultManager] fileExistsAtPath:file];
 				NSImage* image;
-				if(![[NSURL fileURLWithPath:_path isDirectory:_directory] getResourceValue:&image forKey:NSURLEffectiveIconKey error:NULL])
-					image = [[NSWorkspace sharedWorkspace] iconForFile:_path];
+				
+				if (!customFolderIconExists)
+				{
+					if(![[NSURL fileURLWithPath:_path isDirectory:_directory] getResourceValue:&image forKey:NSURLEffectiveIconKey error:NULL])
+					    image = [[NSWorkspace sharedWorkspace] iconForFile:_path];
 
-				if(image)
+					if(image)
+					    [res addObject:image];
+				}
+				else
+				{
+					image = [[NSImage alloc] initWithContentsOfFile:file];
 					[res addObject:image];
+				}
 			}
 		}
 		else if(_exists)


### PR DESCRIPTION
Currently TextMate will defer to `[[NSWorkspace sharedWorkspace] iconForFile` to pick the icon for a folder in the project drawer (https://github.com/textmate/textmate/blob/61bb49ad6e7e24b62a68fa11b1ec674079ac545c/Frameworks/OakAppKit/src/OakFileIconImage.mm#L134)

this PR makes a change such that if a file called `CustomFolder.icns` exists in the project it will be used instead

before:

![screen shot 2014-02-03 at 9 16 03 pm](https://f.cloud.github.com/assets/39759/2073434/c60761f8-8d5b-11e3-830b-e526cb728a8a.png)

after: 

![screen shot 2014-02-03 at 9 18 59 pm](https://f.cloud.github.com/assets/39759/2073436/e5ed66a2-8d5b-11e3-9964-daa39c54110d.png)

This is only my second ever Objective-C patch so I doubt this is implemented the correct way. I'm hoping someone more familiar with TextMate can rewrite this PR to do it properly!
