### PR TITLE
When making the grammar popup menu, store the currently selected grammar

### DIFF
--- a/Frameworks/OakTextView/src/OTVStatusBar.mm
+++ b/Frameworks/OakTextView/src/OTVStatusBar.mm
@@ -170,6 +170,7 @@ static NSButton* OakCreateImageToggleButton (NSImage* image)
 
 - (void)grammarPopUpButtonWillPopUp:(NSNotification*)aNotification
 {
+	NSMenuItem* selectedItem = [self.grammarPopUp selectedItem];
 	NSMenu* grammarMenu = self.grammarPopUp.menu;
 	[grammarMenu removeAllItems];
 
@@ -192,11 +193,7 @@ static NSButton* OakCreateImageToggleButton (NSImage* image)
 
 	[grammarMenu update];
 
-	for(NSMenuItem* item in grammarMenu.itemArray)
-	{
-		if([item state] == NSOnState)
-			[self.grammarPopUp selectItem:item];
-	}
+	[self.grammarPopUp selectItemWithTitle:selectedItem.title];
 }
 
 - (void)bundleItemsPopUpButtonWillPopUp:(NSNotification*)aNotification

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -418,15 +418,6 @@ private:
 		[aMenuItem setState:textView.softTabs ? NSOffState : NSOnState];
 	else if([aMenuItem action] == @selector(setIndentWithSpaces:))
 		[aMenuItem setState:textView.softTabs ? NSOnState : NSOffState];
-	else if([aMenuItem action] == @selector(takeGrammarUUIDFrom:))
-	{
-		NSString* uuidString = [aMenuItem representedObject];
-		if(bundles::item_ptr bundleItem = bundles::lookup(to_s(uuidString)))
-		{
-			bool selectedGrammar = document && document->file_type() == bundleItem->value_for_field(bundles::kFieldGrammarScope);
-			[aMenuItem setState:selectedGrammar ? NSOnState : NSOffState];
-		}
-	}
 	else if([aMenuItem action] == @selector(toggleCurrentBookmark:))
 	{
 		text::selection_t sel([textView.selectionString UTF8String]);


### PR DESCRIPTION
Fixes an issue where the status bar could display the wrong grammar

To reproduce:
- Open a file with some set grammar
- Move focus to file browser (option-command-tab)
- Click on grammar popup button
- Dismiss grammar menu

Result:
- First menu item (Apache) is selected and displayed in the status bar
