### PR TITLE
Improvements in "Show Invisible Characters"

### DIFF
--- a/Frameworks/layout/src/ct.h
+++ b/Frameworks/layout/src/ct.h
@@ -27,6 +27,7 @@ namespace ng
 		std::string tab     = "‣";
 		std::string space   = "·";
 		std::string newline = "¬";
+		std::string special = "┋";
 	};
 
 } /* ng */

--- a/Frameworks/layout/src/paragraph.h
+++ b/Frameworks/layout/src/paragraph.h
@@ -61,7 +61,7 @@ namespace ng
 		bool structural_integrity () const { return true; }
 
 	private:
-		enum node_type_t { kNodeTypeText, kNodeTypeTab, kNodeTypeUnprintable, kNodeTypeFolding, kNodeTypeSoftBreak, kNodeTypeNewline };
+		enum node_type_t { kNodeTypeText, kNodeTypeSpace, kNodeTypeTab, kNodeTypeUnprintable, kNodeTypeFolding, kNodeTypeSoftBreak, kNodeTypeNewline, kNodeTypeSpecial };
 
 		struct node_t
 		{
@@ -93,7 +93,9 @@ namespace ng
 		std::vector<node_t>::iterator iterator_at (size_t i);
 
 		void insert_text (size_t i, size_t len);
+		void insert_space (size_t i, size_t len);
 		void insert_tab (size_t i);
+		void insert_special (size_t i, size_t len);
 		void insert_unprintable (size_t i, size_t len);
 		void insert_newline (size_t i, size_t len);
 


### PR DESCRIPTION
- Spaces (U+20) are also displayed as '.' when showing invisible characters
- No representation for space characters when hiding invisible characters, except for U+FEFF which is deprecated as a space character
- Show a marker for special characters when showing invisible characters
- Changing representation of NO-BREAK SPACE from '.' to '~', to avoid confusion on showing invisible characters

(Related to http://lists.macromates.com/textmate/2014-March/037194.html)
(public domain patch!)
