### PR TITLE
No representation for usual ZERO-WIDTH chars

### DIFF
--- a/Frameworks/layout/src/paragraph.cc
+++ b/Frameworks/layout/src/paragraph.cc
@@ -15,9 +15,6 @@ namespace ng
 		static std::string representation_for (uint32_t ch)
 		{
 			static std::set<uint32_t> const SpaceCharacters = {
-				0x200B, // ZERO WIDTH SPACE
-				0x200C, // ZERO WIDTH NON-JOINER
-				0x200D, // ZERO WIDTH JOINER
 				0x2028, // LINE SEPARATOR
 				0x2029, // PARAGRAPH SEPARATOR
 				0x2060, // WORD JOINER


### PR DESCRIPTION
ZWNJ is so common in Persian texts, and its unicode bi-direction class in neutral.
But the representation chunk contains latin characters and are so left-to-right.
So, when ZWNJ is replaced by the representation chunk, rtl texts are rendered incorrectly.

ZWJ and ZWSP are from the same class, but less common at least in Persian texts.

(Related to https://github.com/textmate/textmate/pull/1217)
