### PR TITLE
Moved OakCreateActionPopUpButton method to OakUIConstructionFunctions.h

### DIFF
--- a/Frameworks/Find/src/FindWindowController.mm
+++ b/Frameworks/Find/src/FindWindowController.mm
@@ -209,7 +209,7 @@ static NSButton* OakCreateStopSearchButton ()
 		self.wherePopUpButton          = OakCreatePopUpButton();
 		self.matchingLabel             = OakCreateLabel(@"matching");
 		self.globTextField             = OakCreateComboBox();
-		self.actionsPopUpButton        = OakCreatePopUpButton(YES /* pulls down */);
+		self.actionsPopUpButton        = OakCreateActionPopUpButton(YES /* bordered */);
 
 		NSScrollView* resultsScrollView = nil;
 		self.resultsTopDivider         = OakCreateHorizontalLine([NSColor colorWithCalibratedWhite:0.500 alpha:1]);
@@ -237,11 +237,8 @@ static NSButton* OakCreateStopSearchButton ()
 		// =============================
 
 		NSMenu* actionMenu = self.actionsPopUpButton.menu;
-		[actionMenu removeAllItems];
 
-		NSMenuItem* titleItem = [actionMenu addItemWithTitle:@"" action:@selector(nop:) keyEquivalent:@""];
-		titleItem.image = [NSImage imageNamed:NSImageNameActionTemplate];
-
+		[actionMenu addItemWithTitle:@"Placeholder" action:@selector(nop:) keyEquivalent:@""];
 		[actionMenu addItemWithTitle:@"Follow Symbolic Links" action:@selector(toggleFollowSymbolicLinks:) keyEquivalent:@""];
 		[actionMenu addItemWithTitle:@"Search Hidden Folders" action:@selector(toggleSearchHiddenFolders:) keyEquivalent:@""];
 		[actionMenu addItem:[NSMenuItem separatorItem]];

--- a/Frameworks/OakAppKit/src/OakUIConstructionFunctions.h
+++ b/Frameworks/OakAppKit/src/OakUIConstructionFunctions.h
@@ -8,6 +8,7 @@ PUBLIC NSTextField* OakCreateSmallLabel (NSString* label = @"");
 PUBLIC NSButton* OakCreateCheckBox (NSString* label);
 PUBLIC NSButton* OakCreateButton (NSString* label, NSBezelStyle bezel = NSRoundedBezelStyle);
 PUBLIC NSPopUpButton* OakCreatePopUpButton (BOOL pullsDown = NO, NSString* initialItemTitle = nil);
+PUBLIC NSPopUpButton* OakCreateActionPopUpButton (BOOL bordered = NO);
 PUBLIC NSPopUpButton* OakCreateStatusBarPopUpButton (NSString* initialItemTitle = nil);
 PUBLIC NSComboBox* OakCreateComboBox ();
 PUBLIC NSImageView* OakCreateDividerImageView ();

--- a/Frameworks/OakAppKit/src/OakUIConstructionFunctions.mm
+++ b/Frameworks/OakAppKit/src/OakUIConstructionFunctions.mm
@@ -63,6 +63,24 @@ NSPopUpButton* OakCreatePopUpButton (BOOL pullsDown, NSString* initialItemTitle)
 	return res;
 }
 
+NSPopUpButton* OakCreateActionPopUpButton (BOOL bordered)
+{
+	NSPopUpButton* res = [NSPopUpButton new];
+	res.bordered  = bordered;
+	res.pullsDown = YES;
+	[[res cell] setBackgroundStyle:NSBackgroundStyleRaised];
+
+	NSMenuItem* item = [NSMenuItem new];
+	item.title = @"";
+	item.image = [NSImage imageNamed:NSImageNameActionTemplate];
+	[item.image setSize:NSMakeSize(14, 14)];
+
+	[[res cell] setUsesItemFromMenu:NO];
+	[[res cell] setMenuItem:item];
+
+	return res;
+}
+
 NSPopUpButton* OakCreateStatusBarPopUpButton (NSString* initialItemTitle)
 {
 	NSPopUpButton* res = OakCreatePopUpButton(NO, initialItemTitle);

--- a/Frameworks/OakFileBrowser/src/ui/OFBActionsView.mm
+++ b/Frameworks/OakFileBrowser/src/ui/OFBActionsView.mm
@@ -23,24 +23,6 @@ static NSButton* OakCreateImageButton (NSImage* image)
 	return res;
 }
 
-static NSPopUpButton* OakCreateActionPopUpButton ()
-{
-	NSPopUpButton* res = [NSPopUpButton new];
-	res.bordered  = NO;
-	res.pullsDown = YES;
-	[[res cell] setBackgroundStyle:NSBackgroundStyleRaised];
-
-	NSMenuItem* item = [NSMenuItem new];
-	item.title = @"";
-	item.image = [NSImage imageNamed:NSImageNameActionTemplate];
-	[item.image setSize:NSMakeSize(14, 14)];
-
-	[[res cell] setUsesItemFromMenu:NO];
-	[[res cell] setMenuItem:item];
-
-	return res;
-}
-
 @implementation OFBActionsView
 - (id)initWithFrame:(NSRect)aRect
 {
@@ -52,7 +34,7 @@ static NSPopUpButton* OakCreateActionPopUpButton ()
 		self.searchButton       = OakCreateImageButton([NSImage imageNamed:@"Search" inSameBundleAsClass:[self class]]);
 		self.favoritesButton    = OakCreateImageButton([NSImage imageNamed:@"Favorites" inSameBundleAsClass:[self class]]);
 		self.scmButton          = OakCreateImageButton([NSImage imageNamed:@"SCM" inSameBundleAsClass:[self class]]);
-		
+
 		self.createButton.toolTip       = @"Create new file";
 		self.reloadButton.toolTip       = @"Reload file browser";
 		self.searchButton.toolTip       = @"Search current folder";


### PR DESCRIPTION
While code reuse is an added benefit, the main motivation was to fix the appearance of the action popup button in the Find window. The first (placeholder) item in the Find window's action button was assigned a nop action so that when the button was clicked and it's menu validated, the "action" image would always appear as disabled.
