### PR TITLE
Add application category for OS X

### DIFF
--- a/Applications/TextMate/resources/Info.plist
+++ b/Applications/TextMate/resources/Info.plist
@@ -13,6 +13,7 @@
 	CFBundlePackageType                  = APPL;
 	CFBundleSignature                    = avin; // we didn’t register this code with Apple
 	LSMinimumSystemVersion               = "${APP_MIN_OS}";
+	LSApplicationCategoryType            = "public.app-category.developer-tools"; // View-->Arrange by Application Category
 	NSAppleScriptEnabled                 = YES;
 	NSMainNibFile                        = MainMenu;
 	NSPrincipalClass                     = NSApplication;


### PR DESCRIPTION
Applications is often not subfoldered and View --> Arrange by Application Category helps but apps need to have this metadata otherwise they're sorted into "Other" at the bottom.  https://developer.apple.com/library/Mac/releasenotes/General/SubmittingToMacAppStore/#//apple_ref/doc/uid/TP40010572-CH16-SW8  (this applies to all Mac apps, not just those coming from App Store)
