### PR TITLE
Minor fixes to commit window

### DIFF
--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -156,16 +156,14 @@ static NSUInteger const kOakCommitWindowCommitMessagesMax = 5;
 		previousCommitMessagesPopUpButton.bordered   = YES;
 		previousCommitMessagesPopUpButton.pullsDown  = YES;
 		previousCommitMessagesPopUpButton.bezelStyle = NSTexturedRoundedBezelStyle;
-		NSMenuItem* placeholder = [NSMenuItem new];
-		placeholder.title = @"Previous Commit Messages";
-		[[previousCommitMessagesPopUpButton cell] setUsesItemFromMenu:NO];
-		[[previousCommitMessagesPopUpButton cell] setMenuItem:placeholder];
 
 		// ========================================
 		// = Create previous commit messages menu =
 		// ========================================
 
 		NSMenu* aMenu = [previousCommitMessagesPopUpButton menu];
+		[aMenu addItemWithTitle:@"Previous Commit Messages" action:@selector(nop:) keyEquivalent:@""];
+
 		NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
 		NSArray* commitMessages = [defaults arrayForKey:kOakCommitWindowCommitMessages];
 		if(commitMessages == nil)


### PR DESCRIPTION
Switching the menu from a popup to pull down caused the first item not to be shown (sorry I missed that). 

Also, feel free to discard 32ef9c8, if you disagree with that choice of display name for the diffs. 
