### PR TITLE
Use NSAccessibilitySharedFocusElementsAttribute in OakChooser

### DIFF
--- a/Frameworks/OakAppKit/src/OakAppKit.h
+++ b/Frameworks/OakAppKit/src/OakAppKit.h
@@ -12,3 +12,8 @@ APPKIT_EXTERN void NSAccessibilityPostNotificationWithUserInfo(id element, NSStr
 APPKIT_EXTERN NSString *const NSAccessibilityAnnouncementRequestedNotification NS_AVAILABLE_MAC(10_7);
 APPKIT_EXTERN NSString *const NSAccessibilityAnnouncementKey            NS_AVAILABLE_MAC(10_7);
 #endif
+
+#if !defined(MAC_OS_X_VERSION_10_10) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10)
+PUBLIC extern NSString *const *const pNSAccessibilitySharedFocusElementsAttribute;
+#define NSAccessibilitySharedFocusElementsAttribute (*pNSAccessibilitySharedFocusElementsAttribute)
+#endif

--- a/Frameworks/OakAppKit/src/OakAppKit.mm
+++ b/Frameworks/OakAppKit/src/OakAppKit.mm
@@ -54,3 +54,13 @@ void OakShowAlertForWindow (NSAlert* alert, NSWindow* window, void(^callback)(NS
 			[alert beginSheetModalForWindow:window modalDelegate:delegate didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:) contextInfo:NULL];
 	else	[delegate sheetDidEnd:alert returnCode:[alert runModal] contextInfo:NULL];
 }
+
+#if !defined(MAC_OS_X_VERSION_10_10) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10)
+// 10.9 and 10.10 SDKs don't define NSAppKitVersionNumber10_9 (nor *_10)
+// literal value taken of 1265 from https://developer.apple.com/library/prerelease/mac/releasenotes/AppKit/RN-AppKit/index.html
+#ifndef NSAppKitVersionNumber10_9
+#define NSAppKitVersionNumber10_9 1265
+#endif
+NSString *const _NSAccessibilitySharedFocusElementsAttribute = @"AXSharedFocusElements";
+NSString *const *const pNSAccessibilitySharedFocusElementsAttribute = (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_9) ? nil : &_NSAccessibilitySharedFocusElementsAttribute;
+#endif

--- a/Frameworks/OakFilterList/src/OakChooser.mm
+++ b/Frameworks/OakFilterList/src/OakChooser.mm
@@ -62,6 +62,8 @@ NSMutableAttributedString* CreateAttributedStringWithMarkedUpRanges (std::string
 		tableView.dataSource              = self;
 		tableView.delegate                = self;
 		tableView.linkedTextField         = _searchField;
+		if (nil != &NSAccessibilitySharedFocusElementsAttribute)
+			[_searchField.cell accessibilitySetOverrideValue:@[tableView] forAttribute:NSAccessibilitySharedFocusElementsAttribute];
 		_tableView = tableView;
 
 		_scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];

--- a/Frameworks/OakFilterList/src/ui/SearchField.mm
+++ b/Frameworks/OakFilterList/src/ui/SearchField.mm
@@ -1,4 +1,5 @@
 #import "SearchField.h"
+#import <OakAppKit/OakAppKit.h>
 
 static id TranslateAXRange(NSRange range, NSUInteger length, id (^process)(NSUInteger left, NSRange range, NSUInteger right), NSUInteger leftMargin = 1, NSUInteger rightMargin = 1)
 {
@@ -164,7 +165,7 @@ static NSString* CreateSpacedString(NSUInteger length)
 @implementation OakLinkedSearchField
 + (void)initialize
 {
-	if(self == OakLinkedSearchField.class)
+	if((nil == &NSAccessibilitySharedFocusElementsAttribute) && (self == OakLinkedSearchField.class))
 	{
 		[OakLinkedSearchField setCellClass:[OakLinkedSearchFieldCell class]];
 	}

--- a/Frameworks/OakFilterList/src/ui/TableView.mm
+++ b/Frameworks/OakFilterList/src/ui/TableView.mm
@@ -22,7 +22,7 @@
 		[_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:extend];
 		[_tableView scrollRowToVisible:row];
 
-		if([sender isKindOfClass:[NSSearchField class]])
+		if((nil == &NSAccessibilitySharedFocusElementsAttribute) && [sender isKindOfClass:[NSSearchField class]])
 		{
 			NSMutableArray* descriptionBits = [NSMutableArray arrayWithCapacity:[_tableView tableColumns].count];
 			[[_tableView tableColumns] enumerateObjectsUsingBlock:^(NSTableColumn* column, NSUInteger index, BOOL* stop) {


### PR DESCRIPTION
This new 10.10 API allows one to mark, for some UI element, a set of UI
elements to track selection. VoiceOver (and other accessibility clients)
will then track and announce selection (cursor) changes not only in the
currently focused element, but also for all elements contained in its
"shared focus elements" array. This is a perfect fit for search field
with a table of results. In fact it is used for new 10.10 Spotlight -
its search field's shared focus element is the table containing the results.

As `NSAccessibilitySharedFocusElementsAttribute` is available only in the 10.10 SDK,
so make a way to use its value with previous SDKs (with which TextMate
is currently compiled).

We also retain the kind-of-hacky solution for pre-10.10 OSes introduced in
and instead use `NSAccessibilitySharedFocusElementsAttribute`.

This code was tested in all 6 fields of a 3×2 matrix:
- compiled with 10.8, 10.9 and 10.10 SDK
- run on 10.9 and 10.10 (DP2)

For user, this means more standard behavior (says the same "completion selected"
thing as with Spotlight) and a bit more correctness (no extra space
before beginning / after end of search field on braille display).

For developer, this means once we stop supporting 10.9, we will be ready to
drop a lot of code which, while serving us well to make the choosers more
user friendly on pre-10.10, will no longer be needed.

I release this patch (and any possible subsequent follow-up patches in this pull request)
to public domain.
