### PR TITLE
Fix enum/int conversion error with 10.10 SDK

### DIFF
--- a/Frameworks/Find/src/attr_string.h
+++ b/Frameworks/Find/src/attr_string.h
@@ -32,8 +32,8 @@ namespace ns
 		};
 		struct line_break
 		{
-			line_break(NSUInteger mode) : mode(mode) {}
-			NSUInteger mode;
+			line_break(NSLineBreakMode mode) : mode(mode) {}
+			NSLineBreakMode mode;
 		};
 	}
 


### PR DESCRIPTION
10.10 SDK makes NSLineBreakMode into a proper NS_ENUM enum (in 10.9 SDK it was
a plain typedef for NSUInteger with some integer NSLineBreak\* values
conveniently available for it in an anonymous enum).

Nevertheless, attr_string code should have always used NSLineBreakMode instead
of NSUInteger (unless I am missing something like values in style::line_break::mode
that do not correspond to the enum), so this commit makes it so and
thus also fixes building with 10.10 SDK.

I am releasing this patch into the public domain.
