### PR TITLE
Fix potential bugs in Variables preference pane

### DIFF
--- a/Frameworks/Preferences/src/VariablesPreferences.mm
+++ b/Frameworks/Preferences/src/VariablesPreferences.mm
@@ -44,6 +44,12 @@
 	NSInteger row = [variablesTableView selectedRow];
 	if(row != -1)
 	{
+		if([variablesTableView editedColumn] != -1)
+		{
+			[variablesTableView abortEditing];
+			[[[self view] window] makeFirstResponder:variablesTableView];
+		}
+
 		[_variables removeObjectAtIndex:row];
 		[[NSUserDefaults standardUserDefaults] setObject:[_variables copy] forKey:kUserDefaultsEnvironmentVariablesKey];
 		[variablesTableView reloadData];


### PR DESCRIPTION
While looking around the code from my previous changes, I notice these two potential bugs. They are edge cases, particularly 873e585 (I doubt anyone actually deletes any of the default rows), but if encountered they do throw exceptions and can leave the table in an unusable state.
