### PR TITLE
Support a "--warn" switch for gen_html.

### DIFF
--- a/Applications/TextMate/about/Contributions.md
+++ b/Applications/TextMate/about/Contributions.md
@@ -13,7 +13,7 @@ See [commits at GitHub][1].
 last_group_heading = ''
 
 require 'bin/gen_credits'
-generate_credits(File.expand_path('~/Library/Caches/com.macromates.TextMate/githubcredits')) do |hash, author, subject, body, userpic, date, github_user|
+generate_credits(File.expand_path('~/Library/Caches/com.macromates.TextMate/githubcredits'), warn) do |hash, author, subject, body, userpic, date, github_user|
   group_heading = date.strftime('%b %e, %Y')
 
   if last_group_heading != group_heading

--- a/bin/gen_credits.rb
+++ b/bin/gen_credits.rb
@@ -4,8 +4,6 @@
 # Module to assist in building the Contributors page using git commit history.
 #
 
-require 'getoptlong'
-require 'rdoc/usage'
 require 'digest/md5'
 require 'net/https'
 require 'uri'
@@ -94,7 +92,7 @@ class GitHubLookup
 
 end
 
-def generate_credits(dbm_file)
+def generate_credits(dbm_file, warn=false)
   GitHubLookup.initialize(dbm_file)
   did_warn_db = Set.new
 
@@ -128,7 +126,9 @@ def generate_credits(dbm_file)
         key = "#{name} <#{fields[2]}>"
         unless did_warn_db.include?(key)
           did_warn_db.add(key)
-          STDERR << "WARNING: failed to find GitHub user for #{key}\n";
+          if warn
+            STDERR << "WARNING: failed to find GitHub user for #{key}\n";
+          end
         end
       end
 

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -66,10 +66,11 @@ opts = GetoptLong.new(
   [ '--title',  '-t', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--header', '-h', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--footer', '-f', GetoptLong::REQUIRED_ARGUMENT ],
+  [ '--warn',   '-w', GetoptLong::NO_ARGUMENT       ],
   [ '--help',         GetoptLong::NO_ARGUMENT       ]
 )
 
-title, header, footer = 'untitled', nil, nil
+title, header, footer, warn = 'untitled', nil, nil, false
 
 opts.each do |opt, arg|
   case opt
@@ -79,6 +80,8 @@ opts.each do |opt, arg|
       header = arg
     when '--footer'
       footer = arg
+    when '--warn'
+      warn = true
   end
 end
 


### PR DESCRIPTION
Default is to suppress any warnings for unassociated GitHub profiles.
