### PR TITLE
Make Commit Window modal

### DIFF
--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -324,6 +324,9 @@ static NSUInteger const kOakCommitWindowCommitMessagesMax = 5;
 		else [view removeFromSuperview];
 	}
 
+	if(!_showsTableView)
+		[self.window makeFirstResponder:self.documentView.textView];
+
 	[[NSUserDefaults standardUserDefaults] setBool:_showsTableView forKey:kOakCommitWindowShowFileList];
 
 	[self updateConstraints];


### PR DESCRIPTION
I welcome any suggestions/comments regarding the visual style. I based it off the sheets in Xcode (under _Source Control_). There a few things we can iterate on. 
- Since we no longer have a title bar, I placed the title above the text view, you may want to change format to something else or drop it entirely.
- The status bar could be hidden.
- One (major) downside is that if we make it sheet, users cannot arbitrarily resize the it.

Let me know if you think it is a improvement, since if we keep changing the style/behavior of the window it could annoy users.
