### PR TITLE
Add Ruby 2.0 support for build scripts

### DIFF
--- a/bin/gen_build
+++ b/bin/gen_build
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -wKU
 # == Synopsis
 #
 # gen_build: create build.ninja based on target files
@@ -17,8 +17,7 @@
 # --define/-d «name»=«value»:
 #    define a variable that ends up in build.ninja.
 
-require 'getoptlong'
-require 'rdoc/usage'
+require 'optparse'
 require 'shellwords'
 require 'set'
 require 'pp'
@@ -641,7 +640,7 @@ def all_targets(buildfile, builddir)
   Dir.chdir(File.dirname(buildfile)) do
     targets = %x{ ${TM_NINJA:-ninja} -f #{buildfile.shellescape} -t targets all }
     return nil if $? != 0
-    targets.each do |line|
+    targets.each_line do |line|
       if line =~ /.*(?=:(?! phony))/
         path = $&
         res << path if path =~ /^#{Regexp.escape(builddir)}/ # ignore targets outside builddir
@@ -656,28 +655,32 @@ end
 # = Program Starts Here =
 # =======================
 
-opts = GetoptLong.new(
-  [ '--help',            '-h', GetoptLong::NO_ARGUMENT       ],
-  [ '--output',          '-o', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--build-directory', '-C', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--define',          '-d', GetoptLong::REQUIRED_ARGUMENT ]
-)
-
 outfile, builddir = '/dev/stdout', File.expand_path('~/build')
 variables = [ ]
 
-opts.each do |opt, arg|
-  case opt
-    when '--help'
-      RDoc::usage
-    when '--output'
-      outfile = arg
-    when '--build-directory'
-      builddir = arg
-    when '--define'
-      variables << [ $1, $2 ] if arg =~ /^(\w+)\s*=\s*(.*)$/
+OptionParser.new do |opts|
+  opts.banner = "Usage: gen_build [options] "
+  opts.separator "Synopsis"
+  opts.separator "gen_build: create build.ninja based on target files"
+  opts.separator "Options:"
+
+  opts.on("-h","--help", "show help.") do |v|
+    puts opts
+    exit
   end
-end
+
+  opts.on("-o","--output FILE", "the «file» to write build info into.") do |v|
+    outfile = v
+  end
+
+  opts.on("-C", "--build-directory DIRECTORY", "where build files should go.") do |v|
+    builddir = v
+  end
+  
+  opts.on("-d", "--define NAME=VALUE", "define a variable that ends up in build.ninja") do |v|
+    variables << [  $1, $2 ] if v =~ /^(\w+)\s*=\s*(.*)$/
+  end
+end.parse!
 
 abort "No root target file specified" if ARGV.empty?
 manifest = ARGV[0]
@@ -698,6 +701,7 @@ open(outfile, "w") do |io|
   io << "include #{userfile}\n" if userfile != 'build.ninja' && File.exists?(File.join(File.dirname(outfile), userfile))
 end
 
+
 open("#{builddir}/build.ninja", "w") do |io|
   user_variables = []
   TARGETS.root.each do |key, value|
@@ -708,10 +712,10 @@ open("#{builddir}/build.ninja", "w") do |io|
   tmp = variables.dup.concat(user_variables) 
   width = tmp.map { |arr| arr[0].length }.max { |lhs, rhs| lhs <=> rhs }
 
-  io << variables.map { |arr| format("%-#{width}s = %s\n", *arr) }
+  variables.map { |arr| format("%-#{width}s = %s\n", *arr) }.each {|item| io << item }
   io << "\n"
 
-  io << user_variables.map { |arr| format("%-#{width}s = %s\n", *arr) }
+  user_variables.map { |arr| format("%-#{width}s = %s\n", *arr) }.each {|item| io << item }
   io << "\n"
 
   args = variables.map { |key, value| "-d'#{key}=#{value =~ /\$/ ? value.gsub(/\$/, '$$') :  "$#{key}"}'" }.join(' ')

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -wKU
 # == Synopsis
 #
 # gen_html: generates HTML file from markdown and optional template(s)
@@ -21,8 +21,7 @@
 #
 # FILE: The markdown document to read (defaults to stdin)
 
-require 'getoptlong'
-require 'rdoc/usage'
+require 'optparse'
 require 'erb'
 
 def expand_tpl(str, binding)
@@ -62,28 +61,31 @@ def wrap_in_article(html)
   end
 end
 
-opts = GetoptLong.new(
-  [ '--title',  '-t', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--header', '-h', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--footer', '-f', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--warn',   '-w', GetoptLong::NO_ARGUMENT       ],
-  [ '--help',         GetoptLong::NO_ARGUMENT       ]
-)
+title, header, footer = 'untitled', nil, nil
 
-title, header, footer, warn = 'untitled', nil, nil, false
+OptionParser.new do |opts|
+  opts.banner = "Usage: gen_html [options] [file]"
+  opts.separator "Synopsis:"
+  opts.separator "gen_html: generates HTML file from markdown and optional template(s)"
+  opts.separator "Options:"
 
-opts.each do |opt, arg|
-  case opt
-    when '--help'
-      RDoc::usage
-    when '--header'
-      header = arg
-    when '--footer'
-      footer = arg
-    when '--warn'
-      warn = true
+  opts.on("-?", "--help", "show help.") do |v|
+    puts opts
+    exit
   end
-end
+
+  opts.on("-h","--header FILE", "prepend «file» as header (erb)") do |arg|
+    header = arg
+  end
+
+  opts.on("-f","--footer FILE", "append «file» as footer (erb)") do |arg|
+    footer = arg
+  end
+
+  opts.on("-t","--title TITLE", "make «title» available to template (as `page_name`)") do |arg|
+    title = arg
+  end
+end.parse!
 
 MARKDOWN_COMPILERS = %w[ multimarkdown ]
 

--- a/bin/process_plist
+++ b/bin/process_plist
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -wKU
 # == Synopsis
 #
 # process_plist: substitute ${VARIABLES} in text files
@@ -8,15 +8,8 @@
 # --help:
 #    show help
 
-require 'getoptlong'
-require 'rdoc/usage'
+require 'optparse'
 require 'shellwords'
-
-opts = GetoptLong.new(
-  [ '--variables', '-v', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--define',    '-d', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--help',      '-h', GetoptLong::NO_ARGUMENT       ]
-)
 
 def parse_variables(path)
   res = { }
@@ -30,19 +23,26 @@ def parse_variables(path)
 end
 
 variables = { }
-
-opts.each do |opt, arg|
-  case opt
-    when '--help'
-      RDoc::usage
-    when '--variables'
-      variables.merge!(parse_variables(arg))
-    when '--define'
-      if arg =~ /^(\w+)\s*(=)[ \t]*(.*)$/
-        variables[$1] = Shellwords.shellwords($3)
-      end
+OptionParser.new do |opts|
+  opts.banner = "Usage: gen_build [options]"
+  opts.separator "Synopsis:"
+  opts.separator "process_plist: substitute ${VARIABLES} in text files"
+  opts.separator "Options:"
+  opts.on("-h","--help", "show help.") do |v|
+    puts opts
+    exit
   end
-end
+
+  opts.on("-v","--variables VARIABLES", "the «file» to write build info into.") do |arg|
+    variables.merge!(parse_variables(arg))
+  end
+
+  opts.on("-d", "--define NAME=VALUE", "define a variable that ends up in build.ninja") do |arg|
+    if arg =~ /^(\w+)\s*(=)[ \t]*(.*)$/
+      variables[$1] = Shellwords.shellwords($3)
+    end
+  end
+end.parse!
 
 while gets
   $_.gsub!(/\$\{(.*?)\}/) do


### PR DESCRIPTION
Switch to OptionParser from GetoptLong/RDoc::usage, which has been removed in ruby 2.0.
Conform to new behavior in IO Class.
Update shebangs.
