### PR TITLE
HOBrowserView: Avoid calling super on key events

### DIFF
--- a/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
+++ b/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
@@ -108,6 +108,45 @@ static void ShowLoadErrorForURL (WebFrame* frame, NSURL* url, NSError* error)
 	}
 }
 
+// ==============
+// = Key Events =
+// ==============
+
+/*
+Since the webView is typically the first responder, the path for key events is as follows:
+
+For keyDown:
+	webView
+	HOBrowserView
+	OakHTMLOutputView
+	NSWindow
+
+For performKeyEquivalent:
+	NSWindow
+	OakHTMLOutputView
+	HOBrowserView
+	webView
+
+A webView default implementation passes all key events, including potential key equivalents (except ESC),
+to the webpage so that it may have a chance to respond. Unfortunately, we cannot know if these events are
+handled so the events are still forwarded down their respective chains as shown above. So to avoid the
+NSBeep when hitting the end of the responder chain, we let HOBrowserView swallow all key events. This is
+safe since performKeyEquivalent: is called first, which leads to another problem: we can pass
+the key event back to the webView (minus the modifier). Therefore, we also terminate the above chain for
+performKeyEquivalent: by overriding the method here and returning just NO. Note: that if none of the views
+in the hierachy returns YES, the key (equivalent) event is then passed to the menus.
+*/
+
+- (BOOL)performKeyEquivalent
+{
+	return NO;
+}
+
+- (void)keyDown:(NSEvent*)anEvent
+{
+
+}
+
 // =========
 // = Swipe =
 // =========


### PR DESCRIPTION
Hopefully, this is a clearer (and the comment is correct). Though, I have to pause and think about it every time. ;)

btw, if we revert the window back to a panel, ESC will still close the window.
