### PR TITLE
Announce current chooser item after edits in search field

### DIFF
--- a/Frameworks/OakFilterList/src/OakChooser.mm
+++ b/Frameworks/OakFilterList/src/OakChooser.mm
@@ -207,6 +207,10 @@ static void* kFirstResponderBinding = &kFirstResponderBinding;
 	}
 
 	[self updateItems:self];
+
+	// see http://lists.apple.com/archives/accessibility-dev/2014/Aug/msg00024.html
+	if(nil != &NSAccessibilitySharedFocusElementsAttribute)
+		NSAccessibilityPostNotification(_tableView, NSAccessibilitySelectedRowsChangedNotification);
 }
 
 - (void)setItems:(NSArray*)anArray


### PR DESCRIPTION
This puts the VoiceOver user experience in OakChooser on par with
Spotlight in Yosemite which also announces currently selected item
after every edit in the search field. This provides the user with
feedback so they know whether the search result changed or did not
change after typing/deleting in the search field.

A manual AXSelectedRowsChanged notification is used - see
http://lists.apple.com/archives/accessibility-dev/2014/Aug/msg00024.html
for discussion about this.

This change is Yosemite-only. While pre-Yosemite OS could probably be
supported in the way it is now for the case when the user moves the
table results with arrow up/down, I did not have time to fiddle with it
and given that Yosemite will be released soon, I am not sure it will be
worth the effort.

I release this patch to the public domain.
