### PR TITLE
Nicer tab items on Yosemite

### DIFF
--- a/Frameworks/OakAppKit/src/OakTabItemView.mm
+++ b/Frameworks/OakAppKit/src/OakTabItemView.mm
@@ -359,17 +359,25 @@
 	NSMutableParagraphStyle* parStyle = [NSMutableParagraphStyle new];
 	[parStyle setLineBreakMode:NSLineBreakByTruncatingMiddle];
 
-	NSShadow* shadow = [NSShadow new];
-	[shadow setShadowColor:[NSColor colorWithCalibratedWhite:1 alpha:0.5]];
-	[shadow setShadowOffset:NSMakeSize(0, -1)];
-	[shadow setShadowBlurRadius:1];
-
-	NSDictionary* attrs = @{
+	NSMutableDictionary* attrs = @{
 		NSParagraphStyleAttributeName  : parStyle,
-		NSFontAttributeName            : [NSFont boldSystemFontOfSize:11],
-		NSForegroundColorAttributeName : [NSColor colorWithCalibratedWhite:(self.active ? 0.2 : 0.5) alpha:1],
-		NSShadowAttributeName          : shadow,
-	};
+		NSForegroundColorAttributeName : [NSColor colorWithCalibratedWhite:(self.active ? 0.2 : 0.5) alpha:1]
+	}.mutableCopy;
+
+	if(oak::os_major() >= 10 && oak::os_minor() >= 10)
+	{
+		attrs[NSFontAttributeName] = [NSFont systemFontOfSize:11];
+	}
+	else
+	{
+		NSShadow* shadow = [NSShadow new];
+		[shadow setShadowColor:[NSColor colorWithCalibratedWhite:1 alpha:0.5]];
+		[shadow setShadowOffset:NSMakeSize(0, -1)];
+		[shadow setShadowBlurRadius:1];
+
+		attrs[NSFontAttributeName]   = [NSFont boldSystemFontOfSize:11];
+		attrs[NSShadowAttributeName] = shadow;
+	}
 
 	_textField.attributedStringValue = [[NSAttributedString alloc] initWithString:_title attributes:attrs];
 }


### PR DESCRIPTION
I removed the text shadow and changed the font to regular weight, to match the style used throughout the system.

Before:

![screen shot 2014-10-20 at 16 11 37](https://cloud.githubusercontent.com/assets/183747/4702453/2b5be344-5863-11e4-9788-d1e9dec0c69a.png)

After:

![screen shot 2014-10-20 at 16 11 51](https://cloud.githubusercontent.com/assets/183747/4702456/2f3388f0-5863-11e4-9ff2-a77fccfa70ba.png)
