### PR TITLE
fixup! Remove NSString `existAtPath` category method

### DIFF
--- a/Frameworks/OakFoundation/src/NSString Additions.h
+++ b/Frameworks/OakFoundation/src/NSString Additions.h
@@ -1,4 +1,4 @@
-@interface NSString (Addition)
+@interface NSString (Additions)
 + (NSString*)stringWithUTF8String:(char const*)aString length:(unsigned)aLength;
 + (NSString*)stringWithCxxString:(std::string const&)aString;
 @end


### PR DESCRIPTION
Add missing "s". Thanks to @simleb for spotting this.
