### PR TITLE
Reorder accessibility order of chooser cell view items

### DIFF
--- a/Frameworks/OakFilterList/src/BundleItemChooser.mm
+++ b/Frameworks/OakFilterList/src/BundleItemChooser.mm
@@ -262,6 +262,16 @@ static std::vector<bundles::item_ptr> relevant_items_in_scope (scope::context_t 
 		self.contextTextField.objectValue = [self valueForKeyPath:@"objectValue.path"];
 	}
 }
+
+- (id)accessibilityAttributeValue:(NSString*)attribute
+{
+	if ([attribute isEqualToString:NSAccessibilityChildrenAttribute])
+	{
+		return @[self.textField.cell, self.imageView.cell, self.contextTextField.cell, self.shortcutTextField.cell];
+	}
+	else
+		return [super accessibilityAttributeValue:attribute];
+}
 @end
 
 @interface BundleItemChooser () <NSToolbarDelegate>

--- a/Frameworks/OakFilterList/src/OakChooser.mm
+++ b/Frameworks/OakFilterList/src/OakChooser.mm
@@ -76,6 +76,16 @@
 		self.folderTextField.objectValue = [self valueForKeyPath:@"objectValue.folder"];
 	}
 }
+
+- (id)accessibilityAttributeValue:(NSString*)attribute
+{
+	if ([attribute isEqualToString:NSAccessibilityChildrenAttribute])
+	{
+		return @[self.textField.cell, self.folderTextField.cell, self.closeButton.cell, self.imageView.cell];
+	}
+	else
+		return [super accessibilityAttributeValue:attribute];
+}
 @end
 
 NSMutableAttributedString* CreateAttributedStringWithMarkedUpRanges (std::string const& in, std::vector< std::pair<size_t, size_t> > const& ranges, NSLineBreakMode lineBreakMode)


### PR DESCRIPTION
When VoiceOver users want to efficiently find an item in a list, they often
go through the items quickly, hearing just first few characters to decide
whether it is the item they want or whether it is positively not the one
(in which case they move to the next item). Therefore it is necessary for
each row (item) of a table to be worded in such a way for VoiceOver so that
the most important piece of information is read first, then followed by the
less important piece of information, etc.

E.g. for the file chooser, the most important piece of information about a
file is its file name. So we put that first for the VoiceOver user. If they
are unsure whether it is the right one (perhaps because there is more than
one file with the same name in different directories), then path to the
file is read after that.

I release these patches into the public domain.
