### PR TITLE
Make Find window's layout unambiguous

### DIFF
--- a/Frameworks/Find/src/FindWindowController.mm
+++ b/Frameworks/Find/src/FindWindowController.mm
@@ -384,12 +384,12 @@ static NSButton* OakCreateStopSearchButton ()
 
 	NSDictionary* views = self.allViews;
 
-	CONSTRAINT(@"H:|-(>=20,==20@75)-[findLabel]-[find(>=100)]",        0);
-	CONSTRAINT(@"H:[find]-(5)-[findHistory]-[count(==findHistory)]-|", NSLayoutFormatAlignAllTop);
-	CONSTRAINT(@"V:[count(==21)]",                                     NSLayoutFormatAlignAllLeft|NSLayoutFormatAlignAllRight);
-	CONSTRAINT(@"H:|-(>=20,==20@75)-[replaceLabel]-[replace]",         0);
-	CONSTRAINT(@"H:[replace]-(5)-[replaceHistory]",                    NSLayoutFormatAlignAllTop);
-	CONSTRAINT(@"V:|-[find]-[replace]",                                NSLayoutFormatAlignAllLeft|NSLayoutFormatAlignAllRight);
+	CONSTRAINT(@"H:|-(>=20,==20@75)-[findLabel]-[find(>=100)]",                          0);
+	CONSTRAINT(@"H:[find]-(5)-[findHistory(==replaceHistory)]-[count(==findHistory)]-|", NSLayoutFormatAlignAllTop);
+	CONSTRAINT(@"V:[count(==21)]",                                                       NSLayoutFormatAlignAllLeft|NSLayoutFormatAlignAllRight);
+	CONSTRAINT(@"H:|-(>=20,==20@75)-[replaceLabel]-[replace]",                           0);
+	CONSTRAINT(@"H:[replace]-(5)-[replaceHistory]",                                      NSLayoutFormatAlignAllTop);
+	CONSTRAINT(@"V:|-[find]-[replace]",                                                  NSLayoutFormatAlignAllLeft|NSLayoutFormatAlignAllRight);
 
 	[_myConstraints addObject:[NSLayoutConstraint constraintWithItem:self.findLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.findTextField attribute:NSLayoutAttributeTop multiplier:1 constant:3]];
 	[_myConstraints addObject:[NSLayoutConstraint constraintWithItem:self.replaceLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.replaceTextField attribute:NSLayoutAttributeTop multiplier:1 constant:3]];


### PR DESCRIPTION
Commit c8f6c1d4406b2ca949e3d893ff7c3097916fea00 (Set content hugging priority to high for our buttons) resulted in the Find window having an unambiguous layout, since this allowed the find text field to potentially grow by reducing the width of the find history and count buttons (such that there is no extra padding surrounding the button's text). To remove the ambiguity we can put another width constraint on these buttons, namely, that they are equal to the replace history button width.
