### PR TITLE
Fix issue where tabs' rects would overlap in the tab bar on Yosemite.

### DIFF
--- a/Frameworks/OakAppKit/src/OakTabBarView.mm
+++ b/Frameworks/OakAppKit/src/OakTabBarView.mm
@@ -279,8 +279,8 @@ static NSString* const OakTabItemPasteboardType = @"OakTabItemPasteboardType";
 {
 	NSUInteger countOfTabs = [anIndexSet count];
 
-	CGFloat spacing = OakTabBarStyle.sharedInstance.tabViewSpacing;
-	CGFloat width   = NSWidth(aRect) - spacing * (countOfTabs-1);
+	CGFloat const spacing = OakTabBarStyle.sharedInstance.tabViewSpacing;
+	CGFloat width = NSWidth(aRect) - spacing * (countOfTabs-1);
 
 	CGFloat totalSurplus = 0;
 	CGFloat totalDeficit = 0;

--- a/Frameworks/OakAppKit/src/OakTabItemView.h
+++ b/Frameworks/OakAppKit/src/OakTabItemView.h
@@ -6,14 +6,14 @@
 PUBLIC @interface OakTabBarStyle : NSObject
 + (instancetype)sharedInstance;
 
-@property (nonatomic) CGFloat leftPadding;
-@property (nonatomic) CGFloat rightPadding;
-@property (nonatomic) CGFloat tabViewSpacing;
-@property (nonatomic) CGFloat minimumTabSize;
-@property (nonatomic) CGFloat maximumTabSize;
+@property (nonatomic, readonly) CGFloat leftPadding;
+@property (nonatomic, readonly) CGFloat rightPadding;
+@property (nonatomic, readonly) CGFloat tabViewSpacing;
+@property (nonatomic, readonly) CGFloat minimumTabSize;
+@property (nonatomic, readonly) CGFloat maximumTabSize;
 
-@property (nonatomic) NSDictionary* activeTabTextStyles;
-@property (nonatomic) NSDictionary* inactiveTabTextStyles;
+@property (nonatomic, readonly) NSDictionary* activeTabTextStyles;
+@property (nonatomic, readonly) NSDictionary* inactiveTabTextStyles;
 
 - (void)setupTabBarView:(OakBackgroundFillView*)aView;
 

--- a/Frameworks/OakAppKit/src/OakTabItemView.mm
+++ b/Frameworks/OakAppKit/src/OakTabItemView.mm
@@ -141,7 +141,7 @@
 		if(oak::os_major() >= 10 && oak::os_minor() >= 10)
 		{
 			_images = [self yosemiteImages];
-			_leftPadding  = -1;
+			_leftPadding  = 0;
 		}
 		else
 		{

--- a/Frameworks/OakAppKit/src/OakTabItemView.mm
+++ b/Frameworks/OakAppKit/src/OakTabItemView.mm
@@ -142,10 +142,12 @@
 		{
 			_images = [self yosemiteImages];
 			_leftPadding  = 0;
+			_rightPadding = 0;
 		}
 		else
 		{
 			_images = [self mavericksImages];
+			_leftPadding  = 0;
 			_rightPadding = -5;
 
 			NSShadow* shadow = [NSShadow new];


### PR DESCRIPTION
I observed this when closing multiple tabs to the right of the active tab on Yosemite.

![screen shot 2015-01-30 at 5 48 27 pm](https://cloud.githubusercontent.com/assets/1371296/5985017/5fe0c99e-a8aa-11e4-9b86-21873fd8acc1.png)

Setting `leftPadding` to 0 fixes the issue (6ea99b4). From studying the code, I am not sure why it was initially set to -1, but of course I might be missing something ;). The other three commits are just some minor changes, which I think make the code a little easier to follow, but feel free to discard them.

