### PR TITLE
fix t_git failed tests

### DIFF
--- a/Frameworks/scm/tests/t_git.cc
+++ b/Frameworks/scm/tests/t_git.cc
@@ -26,6 +26,7 @@ struct setup_t
 		{
 			OAK_FAIL("error in setup: " + script);
 		}
+		sleep(1);
 	}
 
 	scm::status::type status (std::string const& path) const


### PR DESCRIPTION
add `sleep` after io::exec("/bin/sh", "-c", script.c_str(), nullptr) != NULL_STR
I don't know why, some time test will raise error, maybe the file not sync to disk, add sleep will pass tests.

    test_scm: 4 of 32 tests failed:
    Frameworks/scm/tests/t_git.cc:105: Expected (wc.status("folder") == scm::status::mixed), found (clean != mixed)
    Frameworks/scm/tests/t_git.cc:135: Expected (wc.status("folder") == scm::status::mixed), found (clean != mixed)
    Frameworks/scm/tests/t_git.cc:150: Expected (wc.status("folder") == scm::status::deleted), found (clean != deleted)
    Frameworks/scm/tests/t_git.cc:178: Expected (wc.status("folder") == scm::status::deleted), found (clean != deleted)