### PR TITLE
fixup! Use `_externalScopeAttributes` as a fallback to export TM_SCM_NAM...

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -2641,7 +2641,7 @@ static NSUInteger DisableSessionSavingCount = 0;
 	}
 	else
 	{
-		for(auto attr : _externalScopeAttributes)
+		for(auto const& attr : _externalScopeAttributes)
 		{
 			if(regexp::match_t const& m = regexp::search("^attr.scm.(?'TM_SCM_NAME'\\w+)$", attr))
 			{


### PR DESCRIPTION
...E

Added a const reference to avoid the unnecessary copies when using `auto` in range-based for loops. One can find other instances in the code base where we could probably avoid making copies in similar situations, but I did not want to create the patch noise. The intention here is just to correct the obvious mistake and avoid repeating it in the future.