### PR TITLE
Add missing shadow to find/replace history pop-up list

### DIFF
--- a/Frameworks/OakAppKit/src/OakPasteboardSelector.mm
+++ b/Frameworks/OakAppKit/src/OakPasteboardSelector.mm
@@ -298,6 +298,7 @@ static size_t line_count (std::string const& text)
 	{
 		[self setShouldCascadeWindows:NO];
 		[self window];
+		self.window.hasShadow = YES;
 	}
 	return self;
 }


### PR DESCRIPTION
The NSComboBox, whose pop-up list has shadow, and so it will be nice for this similar control.

before:
![without shadow](http://i.imgur.com/cWU1j8a.png?1)

after:
![with shadow](http://i.imgur.com/8gR1wuh.png?1)