### PR TITLE
Fix t_bump_date timezone

### DIFF
--- a/Frameworks/OakAppKit/tests/t_bump_date.mm
+++ b/Frameworks/OakAppKit/tests/t_bump_date.mm
@@ -3,9 +3,15 @@
 
 void test_bump_date ()
 {
-	NSDate* date = [NSDate dateWithString:@"2015-03-25 00:00:00 +0000"];
+    NSDate* date = [NSDate date];
+    NSDateFormatter* dateFmt = [NSDateFormatter new];
+    dateFmt.dateFormat = @"yyyy-MM-dd";
+    NSString* formatted = [dateFmt stringFromDate:date];
 
-	OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"2014-03-02 Invoice 37.tex", date)),   "2015-03-25 Invoice 37.tex");
-	OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"2014-03-02_Invoice 37.tex", date)),   "2015-03-25_Invoice 37.tex");
-	OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"Invoice 37 (2014-03-02).tex", date)), "Invoice 37 (2015-03-25).tex");
+    OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"2014-03-02 Invoice 37.tex", date)),
+                  to_s([NSString stringWithFormat:@"%@ Invoice 37.tex", formatted]));
+    OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"2014-03-02_Invoice 37.tex", date)),
+                  to_s([NSString stringWithFormat:@"%@_Invoice 37.tex", formatted]));
+    OAK_ASSERT_EQ(to_s(OakReplaceDateInString(@"Invoice 37 (2014-03-02).tex", date)),
+                  to_s([NSString stringWithFormat:@"Invoice 37 (%@).tex", formatted]));
 }


### PR DESCRIPTION
Had a little trouble building my fork recently.

```
deimos:textmate ((5a1754b...)) λ ninja
[1/1] Generate ‘build.ninja’…
[4/36] Run test ‘/Users/jgavris/build/TextMate/Frameworks/OakAppKit/test_OakAppKit’…
FAILED: /Users/jgavris/build/TextMate/Frameworks/OakAppKit/test_OakAppKit && touch /Users/jgavris/build/TextMate/Frameworks/OakAppKit/test_OakAppKit.run
test_OakAppKit: 1 of 1 test failed:
/Users/jgavris/Documents/textmate/Frameworks/OakAppKit/tests/t_bump_date.mm:8: Expected (to_s(OakReplaceDateInString(@"2014-03-02 Invoice 37.tex", date)) == "2015-03-25 Invoice 37.tex"), found ("2015-03-24 Invoice 37.tex" != "2015-03-25 Invoice 37.tex")
ninja: build stopped: subcommand failed.
```