### PR TITLE
Use googles dense-hash-map for theme cache speedup

### DIFF
--- a/Frameworks/scope/src/scope.cc
+++ b/Frameworks/scope/src/scope.cc
@@ -4,6 +4,7 @@
 #include <text/parse.h>
 #include <text/tokenize.h>
 #include <oak/oak.h>
+#include <functional>
 
 namespace scope
 {
@@ -13,7 +14,7 @@ namespace scope
 	// = scope_t::node_t =
 	// ===================
 
-	scope_t::node_t::node_t (std::string const& atoms, node_t* parent) : _atoms(atoms), _parent(parent), _retain_count(1)
+	scope_t::node_t::node_t (std::string const& atoms, node_t* parent) : _atoms(atoms), _parent(parent), _retain_count(1), _hash(std::hash<std::string>()(atoms) ^ (parent ? parent->_hash : 0))
 	{
 	}
 
@@ -174,6 +175,8 @@ namespace scope
 
 	bool scope_t::operator!= (scope_t const& rhs) const   { return !(*this == rhs); }
 	scope_t::operator bool () const                       { return !empty(); }
+
+	size_t scope_t::hash () const { return node ? node->_hash : 0 ; }
 
 	scope_t shared_prefix (scope_t const& lhs, scope_t const& rhs)
 	{

--- a/Frameworks/scope/src/scope.h
+++ b/Frameworks/scope/src/scope.h
@@ -43,6 +43,7 @@ namespace scope
 		explicit operator bool () const;
 		explicit operator std::string () const;
 
+		size_t hash () const;
 	private:
 		struct node_t
 		{
@@ -65,6 +66,7 @@ namespace scope
 			std::string _atoms;
 			node_t* _parent;
 			std::atomic_size_t _retain_count;
+			size_t _hash;
 		};
 
 		explicit scope_t (node_t* node);
@@ -118,4 +120,11 @@ namespace scope
 
 } /* scope */
 
+template<> struct std::hash<scope::scope_t>
+{
+	size_t operator()(scope::scope_t const& scope) const
+	{
+		 return scope.hash();
+	}
+};
 #endif /* end of include guard: SCOPE_SELECTOR_H_WZ1A8GIC */

--- a/Frameworks/theme/src/theme.cc
+++ b/Frameworks/theme/src/theme.cc
@@ -178,6 +178,7 @@ theme_ptr theme_t::copy_with_font_name_and_size (std::string const& fontName, CG
 theme_t::theme_t (bundles::item_ptr const& themeItem, std::string const& fontName, CGFloat fontSize) :_item(themeItem), _font_name(fontName), _font_size(fontSize)
 {
 	_styles = find_shared_styles(themeItem);
+	_cache.set_empty_key(scope::scope_t{});
 }
 
 static CGColorRef OakColorCreateCopySoften (CGColorPtr cgColor, CGFloat factor)
@@ -377,8 +378,7 @@ styles_t const& theme_t::styles_for_scope (scope::scope_t const& scope) const
 {
 	ASSERT(scope);
 
-	std::string const key = to_s(scope);
-	std::map<std::string, styles_t>::iterator styles = _cache.find(key);
+	auto styles = _cache.find(scope);
 	if(styles == _cache.end())
 	{
 		std::multimap<double, decomposed_style_t> ordering;
@@ -413,7 +413,7 @@ styles_t const& theme_t::styles_for_scope (scope::scope_t const& scope) const
 		CGColorPtr selection  = OakColorCreateFromThemeColor(base.selection,  _styles->_color_space) ?: CGColorPtr(CGColorCreate(_styles->_color_space, (CGFloat[4]){ 0.5, 0.5, 0.5,   1 }), CGColorRelease);
 
 		styles_t res(foreground, background, caret, selection, font, base.underlined == bool_true, base.misspelled == bool_true);
-		styles = _cache.emplace(key, res).first;
+		styles = _cache.insert(std::make_pair(scope, res)).first;
 	}
 	return styles->second;
 }

--- a/Frameworks/theme/src/theme.h
+++ b/Frameworks/theme/src/theme.h
@@ -3,6 +3,7 @@
 
 #include <bundles/bundles.h>
 #include <scope/scope.h>
+#include <sparsehash/dense_hash_map>
 
 typedef std::shared_ptr<struct __CTFont const> CTFontPtr;
 typedef std::shared_ptr<struct CGColor> CGColorPtr;
@@ -11,6 +12,7 @@ struct PUBLIC styles_t
 {
 	styles_t (CGColorPtr foreground, CGColorPtr background, CGColorPtr caret, CGColorPtr selection, CTFontPtr font, bool underlined, bool misspelled) : _foreground(foreground), _background(background), _caret(caret), _selection(selection), _font(font), _underlined(underlined), _misspelled(misspelled) { }
 
+	styles_t () = default;
 	CGColorRef foreground () const { return _foreground.get(); }
 	CGColorRef background () const { return _background.get(); }
 	CGColorRef caret () const      { return _caret.get(); }
@@ -140,7 +142,7 @@ private:
 	std::string _font_name;
 	CGFloat _font_size;
 
-	mutable std::map<std::string, styles_t> _cache;
+	mutable google::dense_hash_map<scope::scope_t, styles_t> _cache;
 };
 
 PUBLIC theme_ptr parse_theme (bundles::item_ptr const& themeItem);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To bootstrap the build you need to run `./configure` (in the root of the source 
 * `builddir` — location of built files. Defaults to `~/build/TextMate`.
 * `identity` — for Apple’s `codesign`. Defaults to ad-hoc signing, which does not use an identity at all.
 * `boostdir` — location of boost includes. By default it will search various locations including MacPorts and Homebrew.
+* `sparsedir` — location of sparsehash includes. By default it will search various locations including MacPorts and Homebrew.
 * `CC` and `CXX` — C and C++ compiler.
 
 In the simplest case you would run:
@@ -43,13 +44,14 @@ To build the source the following must first be installed on your system:
  * [ninja][]         — build system similar to `make`
  * [ragel][]         — state machine compiler
  * [boost][]         — portable C++ source libraries
+ * [sparsehash][]    — A cache friendly hash_map
  * [multimarkdown][] — marked-up plain text compiler
  * [mercurial][]     — distributed SCM system
  * [Cap’n Proto][capnp] — serialization library
 
 You need to manually install [Cap’n Proto][capnp] if you're not using [homebrew][]. To install the other dependencies via [MacPorts][] run:
 
-	sudo port install ninja ragel boost multimarkdown mercurial
+	sudo port install ninja ragel boost multimarkdown mercurial sparsehash
 
 If `port` fails with a build error then likely you need to agree (system-wide) to Apple’s Xcode license:
 
@@ -57,7 +59,7 @@ If `port` fails with a build error then likely you need to agree (system-wide) t
 
 To install using [homebrew][] run:
 
-	brew install ragel boost multimarkdown hg ninja capnp
+	brew install ragel boost multimarkdown hg ninja capnp google-sparsehash
 
 In practice `hg` ([mercurial][]) is only required for the SCM library’s tests so you can skip this dependency if you don’t mind a failing test.
 
@@ -135,5 +137,6 @@ TextMate is a trademark of Allan Odgaard.
 [homebrew]:      http://brew.sh/
 [NinjaBundle]:   https://github.com/textmate/ninja.tmbundle
 [CxxTest]:       https://github.com/textmate/cxxtest.tmbundle
+[sparsehash]:    https://code.google.com/p/sparsehash/
 [#textmate]:     irc://irc.freenode.net/#textmate
 [freenode.net]:  http://freenode.net/

--- a/configure
+++ b/configure
@@ -37,6 +37,22 @@ done
 
 test -L "${builddir}/include/boost" || error "*** boost not installed."
 
+# ===========================================
+# = Check if google sparsehash is installed =
+# ===========================================
+
+if which -s brew && [[ -z "$sparsedir" && ! -d /usr/local/include/sparsehash ]]; then
+	sparsedir=$(brew --prefix google-sparsehash)/include/sparsehash
+fi
+for dir in "${sparsedir:-/usr/include/sparsehash}" /{opt,usr}/local/include/sparsehash/ ; do
+	if [[ ! -L "${builddir}/include/sparsehash" && -d "${dir}" ]]; then
+		mkdir -p "${builddir}/include" && ln -fs "${dir}" "${builddir}/include/sparsehash"
+	fi
+done
+
+test -L "${builddir}/include/sparsehash" || error "*** google sparsehash not installed."
+ 
+ 
 # ===============================================
 # = Check if we can use pbzip2 instead of bzip2 =
 # ===============================================


### PR DESCRIPTION
Googles sparse-hash-map library contains a dense-hash-map. It is about 60-70% faster than c++ std::map, when looking up Textmate's scope::scope_t.

This patch switches the theme scope cache from std::map to google::dense_hash_map.