### PR TITLE
Fixed fatal error in Applications/indent/indent.cc

### DIFF
--- a/Applications/indent/src/indent.cc
+++ b/Applications/indent/src/indent.cc
@@ -76,7 +76,7 @@ int main (int argc, char const* argv[])
 		files.push_back("/Users/duff/Desktop/indent-test.html");
 
 	plist::dictionary_t plist = plist::load(patterns);
-	static std::map<indent::pattern_type, std::string> const map =
+	static std::map<std::string, indent::pattern_type> const map =
 	{
 		{ "increaseIndentPattern", indent::pattern_type::kIncrease     },
 		{ "decreaseIndentPattern", indent::pattern_type::kDecrease     },


### PR DESCRIPTION
The static `std::map` instance (named just `map`, on line 79) had its initializer template params in the wrong order, which kept it from compiling. Swapping them as per this PR lets `indent` build and run with no issues.