### PR TITLE
Use pthread method for thread local storage

### DIFF
--- a/Frameworks/crash/src/info.cc
+++ b/Frameworks/crash/src/info.cc
@@ -1,6 +1,6 @@
 #include "info.h"
-#include <boost/thread/tss.hpp>
 #include <oak/debug.h>
+#include <oak/tls_ptr.h>
 
 /* CrashReporter info */
 char const* __crashreporter_info__ = nullptr;
@@ -59,10 +59,7 @@ namespace
 
 	static stack_t& stack ()
 	{
-		static boost::thread_specific_ptr<stack_t> stackPtr;
-		if(!stackPtr.get())
-			stackPtr.reset(new stack_t);
-
+		static oak::tls_ptr_t<stack_t> stackPtr;
 		return *stackPtr;
 	}
 }

--- a/Frameworks/crash/target
+++ b/Frameworks/crash/target
@@ -1,3 +1,3 @@
 SOURCES       = src/*.cc
 EXPORT        = src/*.h
-LN_FLAGS     += /usr/local/lib/libboost_thread-mt.a /usr/local/lib/libboost_system-mt.a
+

--- a/Shared/include/oak/tls_ptr.h
+++ b/Shared/include/oak/tls_ptr.h
@@ -1,0 +1,39 @@
+#ifndef TLS_PTR_H_186F0BAB
+#define TLS_PTR_H_186F0BAB
+
+namespace oak
+{
+	template<typename T>
+	struct tls_ptr_t
+	{
+	public:
+		tls_ptr_t () { pthread_key_create(&_key, destructor); }
+
+		~tls_ptr_t () {}
+
+		tls_ptr_t(tls_ptr_t const& rhs) = delete;
+		tls_ptr_t& operator=(tls_ptr_t const& rhs) = delete;
+
+		T& operator*  () const { return *get(); }
+		T* operator-> () const { return  get(); }
+
+	private:
+		T* get () const
+		{
+			T* valuePtr = static_cast<T*>(pthread_getspecific(_key));
+			if(!valuePtr)
+			{
+				pthread_setspecific(_key, new T);
+				valuePtr = static_cast<T*>(pthread_getspecific(_key));
+			}
+			return valuePtr;
+		}
+
+		static void destructor(void* valuePtr) { delete static_cast<T*>(valuePtr); }
+
+		pthread_key_t _key;
+
+	};
+} /* oak */
+
+#endif /* end of include guard: TLS_PTR_H_186F0BAB */

--- a/target
+++ b/target
@@ -28,8 +28,6 @@ LN_FLAGS += -rpath @executable_path/../Frameworks
 CXX_FLAGS += -I"$capnp_prefix/include"
 LN_FLAGS  += -L"$capnp_prefix/lib"
 
-LN_FLAGS += /usr/local/lib/libboost_thread-mt.a /usr/local/lib/libboost_system-mt.a
-
 PRELUDE = Shared/PCH/prelude.*
 
 TARGETS  = vendor/*/target


### PR DESCRIPTION
This effectively undoes 172ce9d4282e408fe60b699c432390b9f6e3f74a. It seems Apple discourage static linking and the new version of clang in Xcode 7 issue warnings when the target builds are different. 
