### PR TITLE
Silence a couple of false warnings with about unused local typedefs

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -230,6 +230,14 @@ struct buffer_refresh_callback_t;
 typedef indexed_map_t<OakAccessibleLink*> links_t;
 typedef std::shared_ptr<links_t> links_ptr;
 
+typedef NS_ENUM(NSUInteger, OakFlagsState) {
+	OakFlagsStateClear = 0,
+	OakFlagsStateOptionDown,
+	OakFlagsStateShiftDown,
+	OakFlagsStateShiftTapped,
+	OakFlagsStateSecondShiftDown,
+};
+
 @interface OakTextView () <NSTextInputClient, NSDraggingSource, NSIgnoreMisspelledWords, NSChangeSpelling, NSTextFieldDelegate>
 {
 	OBJC_WATCH_LEAKS(OakTextView);
@@ -313,7 +321,7 @@ typedef std::shared_ptr<links_t> links_ptr;
 @property (nonatomic, readonly) ng::ranges_t const& markedRanges;
 @property (nonatomic) NSDate* lastFlagsChangeDate;
 @property (nonatomic) NSUInteger lastFlags;
-@property (nonatomic) NSUInteger flagsState;
+@property (nonatomic) OakFlagsState flagsState;
 @property (nonatomic) OakTimer* initiateDragTimer;
 @property (nonatomic) OakTimer* dragScrollTimer;
 @property (nonatomic) BOOL showDragCursor;
@@ -1984,14 +1992,6 @@ static void update_menu_key_equivalents (NSMenu* menu, std::multimap<std::string
 
 - (void)flagsChanged:(NSEvent*)anEvent
 {
-	typedef NS_ENUM(NSUInteger, OakFlagsState) {
-		OakFlagsStateClear = 0,
-		OakFlagsStateOptionDown,
-		OakFlagsStateShiftDown,
-		OakFlagsStateShiftTapped,
-		OakFlagsStateSecondShiftDown,
-	};
-
 	NSInteger modifiers  = [anEvent modifierFlags] & (NSAlternateKeyMask | NSControlKeyMask | NSCommandKeyMask | NSShiftKeyMask);
 	BOOL isHoldingOption = modifiers & NSAlternateKeyMask ? YES : NO;
 

--- a/Shared/PCH/prelude.cc
+++ b/Shared/PCH/prelude.cc
@@ -22,6 +22,10 @@
 #include <thread>
 #include <boost/crc.hpp>
 #include <boost/variant.hpp>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
 #include <sparsehash/dense_hash_map>
+#pragma clang diagnostic pop
 
 #endif /* end of include guard: PRELUDE_CC_PCH_U5CKEP2N */


### PR DESCRIPTION
The new release of clang with Xcode 7 now turns on warnings for unused local typedefs. This triggers warnings in OakTextView and the sparsehash library, but they seem to be false positive. This PR silence them nonetheless, since in the case of the sparsehash library the output is very noisy.