### PR TITLE
Fix some build errors with the new 10.11 SDK

### DIFF
--- a/Applications/TextMate/src/AboutWindowController.mm
+++ b/Applications/TextMate/src/AboutWindowController.mm
@@ -242,7 +242,11 @@ static NSTextField* OakCreateTextField ()
 
 // ============================
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface AboutWindowController () <NSWindowDelegate, NSToolbarDelegate>
+#else
+@interface AboutWindowController () <NSWindowDelegate, NSToolbarDelegate, WebFrameLoadDelegate, WebPolicyDelegate>
+#endif
 @property (nonatomic) NSToolbar* toolbar;
 @property (nonatomic) WebView* webView;
 @property (nonatomic) NSString* selectedPage;

--- a/Frameworks/HTMLOutput/src/browser/HOBrowserView.h
+++ b/Frameworks/HTMLOutput/src/browser/HOBrowserView.h
@@ -2,7 +2,11 @@
 
 @class HOStatusBar;
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface HOBrowserView : NSView
+#else
+@interface HOBrowserView : NSView <WebFrameLoadDelegate>
+#endif
 @property (nonatomic, readonly) WebView* webView;
 @property (nonatomic, readonly) BOOL needsNewWebView;
 @property (nonatomic, readonly) HOStatusBar* statusBar;

--- a/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
+++ b/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
@@ -16,7 +16,11 @@ static void ShowLoadErrorForURL (WebFrame* frame, NSURL* url, NSError* error)
 	[frame loadHTMLString:errorMsg baseURL:[NSURL fileURLWithPath:NSTemporaryDirectory()]];
 }
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface HOBrowserView ()
+#else
+@interface HOBrowserView () <WebPolicyDelegate, WebUIDelegate, WebResourceLoadDelegate>
+#endif
 @property (nonatomic, readwrite) WebView* webView;
 @property (nonatomic, readwrite) HOStatusBar* statusBar;
 @property (nonatomic) HOWebViewDelegateHelper* webViewDelegateHelper;

--- a/Frameworks/HTMLOutput/src/browser/HOWebViewDelegateHelper.h
+++ b/Frameworks/HTMLOutput/src/browser/HOWebViewDelegateHelper.h
@@ -2,7 +2,11 @@
 @property (nonatomic) NSString* statusText;
 @end
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface HOWebViewDelegateHelper : NSObject
+#else
+@interface HOWebViewDelegateHelper : NSObject <WebResourceLoadDelegate, WebUIDelegate>
+#endif
 @property (nonatomic, weak) id /*<HOWebViewDelegateHelperProtocol>*/ delegate;
 @property (nonatomic) BOOL needsNewWebView;
 @end

--- a/Frameworks/HTMLOutput/src/browser/HOWebViewDelegateHelper.mm
+++ b/Frameworks/HTMLOutput/src/browser/HOWebViewDelegateHelper.mm
@@ -44,7 +44,7 @@ OAK_DEBUG_VAR(HTMLOutput_WebViewDelegate);
 	NSOpenPanel* panel = [NSOpenPanel openPanel];
 	[panel setDirectoryURL:[NSURL fileURLWithPath:NSHomeDirectory()]];
 	if([panel runModal] == NSOKButton)
-		[resultListener chooseFilename:[[[[panel URLs] objectAtIndex:0] fileURL] path]];
+		[resultListener chooseFilename:[[[panel URLs] objectAtIndex:0] path]];
 }
 
 - (WebView*)webView:(WebView*)sender createWebViewWithRequest:(NSURLRequest*)request

--- a/Frameworks/OakAppKit/src/OakPasteboardChooser.mm
+++ b/Frameworks/OakAppKit/src/OakPasteboardChooser.mm
@@ -45,7 +45,11 @@
 }
 @end
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface OakPasteboardChooser () <NSWindowDelegate, NSTextFieldDelegate, NSTableViewDelegate>
+#else
+@interface OakPasteboardChooser () <NSWindowDelegate, NSTextFieldDelegate, NSTableViewDelegate, NSSearchFieldDelegate>
+#endif
 @property (nonatomic) OakPasteboard*        pasteboard;
 @property (nonatomic) NSArrayController*    arrayController;
 @property (nonatomic) NSWindow*             window;

--- a/Frameworks/OakFileBrowser/src/ui/OFBOutlineView.mm
+++ b/Frameworks/OakFileBrowser/src/ui/OFBOutlineView.mm
@@ -19,7 +19,7 @@
 	NSSize defaultIntercellSpacing;
 	NSColor* defaultBackgroundColor;
 }
-@property (nonatomic) NSArray* draggedItems;
+@property (nonatomic) NSArray* draggedOFBItems;
 
 - (void)performDoubleClick:(id)sender;
 @end
@@ -210,15 +210,15 @@
 		if(id item = [self itemAtRow:index])
 			[items addObject:item];
 	}
-	self.draggedItems = items;
+	self.draggedOFBItems = items;
 	return [super dragImageForRowsWithIndexes:anIndexSet tableColumns:anArray event:anEvent offset:aPointPointer];
 }
 
 - (void)draggedImage:(NSImage*)anImage endedAt:(NSPoint)aPoint operation:(NSDragOperation)aDragOperation
 {
-	if(self.draggedItems && [self.dataSource respondsToSelector:@selector(outlineView:draggedItems:endedWithOperation:)])
-		[(id <FSDataSourceDragSource>)self.dataSource outlineView:self draggedItems:self.draggedItems endedWithOperation:aDragOperation];
-	self.draggedItems = nil;
+	if(self.draggedOFBItems && [self.dataSource respondsToSelector:@selector(outlineView:draggedItems:endedWithOperation:)])
+		[(id <FSDataSourceDragSource>)self.dataSource outlineView:self draggedItems:self.draggedOFBItems endedWithOperation:aDragOperation];
+	self.draggedOFBItems = nil;
 
 	if([NSOutlineView respondsToSelector:@selector(draggedImage:endedAt:operation:)])
 		[super draggedImage:anImage endedAt:aPoint operation:aDragOperation];

--- a/Frameworks/OakFilterList/src/OakChooser.mm
+++ b/Frameworks/OakFilterList/src/OakChooser.mm
@@ -108,7 +108,11 @@ NSMutableAttributedString* CreateAttributedStringWithMarkedUpRanges (std::string
 	return res;
 }
 
+#if !defined(MAC_OS_X_VERSION_10_11) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11)
 @interface OakChooser () <NSWindowDelegate, NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate>
+#else
+@interface OakChooser () <NSWindowDelegate, NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSSearchFieldDelegate>
+#endif
 @end
 
 static void* kFirstResponderBinding = &kFirstResponderBinding;


### PR DESCRIPTION
This resolves most of the errors when building with the new SDK. The only remaining issue is that the headers for `openssl` are no longer included. For now, I just installed the missing headers via brew and copy them over when building. I don't know if you want go with the above approach or update the code to use `CommonCrypto`/`Security Transforms`.

As for 9e4e88c, I submitted a radar but I have not heard back.