### PR TITLE
[RFC] Replace system provided openssl with LibreSSL

### DIFF
--- a/Frameworks/license/src/license.cc
+++ b/Frameworks/license/src/license.cc
@@ -5,12 +5,6 @@
 #include <text/tokenize.h>
 #include <text/case.h>
 #include <text/format.h>
-
-#ifdef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
-#undef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
-#define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
-#endif
-
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>

--- a/Frameworks/license/target
+++ b/Frameworks/license/target
@@ -1,6 +1,7 @@
 SOURCES      = src/*.cc
 EXPORT       = src/{license,keychain}.h
 LINK        += text cf
+CXX_FLAGS   += -I"$libressl_prefix/include"
 LN_FLAGS    += -Wl,-U,__Z15revoked_serialsv
-LIBS         = crypto
+LN_FLAGS    += "$libressl_prefix"/lib/libcrypto.a
 FRAMEWORKS   = Security

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ To build the source the following must first be installed on your system:
  * [multimarkdown][] — marked-up plain text compiler
  * [mercurial][]     — distributed SCM system
  * [Cap’n Proto][capnp] — serialization library
+ * [LibreSSL][libressl] - OpenBSD fork of OpenSSL 
 
 You need to manually install [Cap’n Proto][capnp] if you're not using [homebrew][]. To install the other dependencies via [MacPorts][] run:
 
-	sudo port install ninja ragel boost multimarkdown mercurial sparsehash
+	sudo port install ninja ragel boost multimarkdown mercurial sparsehash libressl
 
 If `port` fails with a build error then likely you need to agree (system-wide) to Apple’s Xcode license:
 
@@ -59,7 +60,7 @@ If `port` fails with a build error then likely you need to agree (system-wide) t
 
 To install using [homebrew][] run:
 
-	brew install ragel boost multimarkdown hg ninja capnp google-sparsehash
+	brew install ragel boost multimarkdown hg ninja capnp google-sparsehash libressl
 
 In practice `hg` ([mercurial][]) is only required for the SCM library’s tests so you can skip this dependency if you don’t mind a failing test.
 
@@ -132,6 +133,7 @@ TextMate is a trademark of Allan Odgaard.
 [ragel]:         http://www.complang.org/ragel/
 [mercurial]:     http://mercurial.selenic.com/
 [capnp]:         http://kentonv.github.io/capnproto/
+[libressl]:      http://www.libressl.org
 [clang 3.2]:     http://clang.llvm.org/
 [MacPorts]:      http://www.macports.org/
 [homebrew]:      http://brew.sh/

--- a/configure
+++ b/configure
@@ -53,6 +53,20 @@ done
 
 test -L "${builddir}/include/sparsehash" || error "*** google sparsehash not installed."
 
+# ===========================================
+# = Check if non-system openssl is intalled =
+# ===========================================
+
+if which -s brew && [[ -z "$libressl_prefix" && ! -d "${libressl_prefix}/include/openssl" ]]; then
+	libressl_prefix=$(brew --prefix libressl)
+        test -d "${libressl_prefix}/include/" || error "*** openssl headers not found."
+fi
+
+if which -s port && [[ -z "$libressl_prefix" && ! -d "${libressl_prefix}/include/openssl" ]]; then
+        libressl_prefix=/opt/local/
+        test -d "${libressl_prefix}/include/openssl" || error "*** openssl headers not found."
+fi
+
 # ===============================================
 # = Check if we can use pbzip2 instead of bzip2 =
 # ===============================================
@@ -79,7 +93,7 @@ done
 mkdir -p "$builddir/Frameworks/SoftwareUpdate/fixtures"
 DST=$(cd >/dev/null "$builddir/Frameworks/SoftwareUpdate/fixtures"; pwd) make -C Frameworks/SoftwareUpdate/fixtures
 
-bin/gen_build -o build.ninja -C "$builddir" -dAPP_NAME="$name" -dAPP_VERSION="$ver" -dAPP_MIN_OS="$min_os" -dCC="$CC" -dCXX="$CXX" -didentity="$identity" -drest_api="$rest_api" -dbzip2_flag="$bzip2_flag" -dcapnp_prefix="$capnp_prefix" target
+bin/gen_build -o build.ninja -C "$builddir" -dAPP_NAME="$name" -dAPP_VERSION="$ver" -dAPP_MIN_OS="$min_os" -dCC="$CC" -dCXX="$CXX" -didentity="$identity" -drest_api="$rest_api" -dbzip2_flag="$bzip2_flag" -dcapnp_prefix="$capnp_prefix" -dlibressl_prefix="$libressl_prefix" target
 
 ninja Frameworks/encoding/src/frequencies.capnp.h
 ninja Frameworks/plist/src/cache.capnp.h


### PR DESCRIPTION
This is follow up to #1301. 

I thought about having the build default to use the system headers if present (e.g., building on 10.10 or older), but I think it easier instead to just require a more recent version of the openssl headers and statically link it.

I have not tested this with Macports so I don't know if the paths in `configure` are right (I plan on testing it in a few days). Thoughts?