### PR TITLE
Add project scope for Cargo (Rust) projects (attr.project.cargo)

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -1308,6 +1308,7 @@ namespace
 		{ "attr.project.maven",   "pom.xml",        "build"   },
 		{ "attr.project.scons",   "SConstruct",     "build"   },
 		{ "attr.project.lein",    "project.clj",    "build"   },
+		{ "attr.project.cargo",   "Cargo.toml",     "build"   },
 		{ "attr.project.vagrant", "Vagrantfile",    "vagrant" },
 		{ "attr.project.jekyll",  "_config.yml",    "jekyll"  },
 		{ "attr.test.rspec",      ".rspec",         "test"    },

--- a/Frameworks/OakAppKit/icons/bindings.plist
+++ b/Frameworks/OakAppKit/icons/bindings.plist
@@ -13,7 +13,7 @@
 	list                 = ( gtd, gtdlog, properties, json, strings, plist, dict, scriptsuite, scriptterminology, savedsearch, defs.rem, reminders, TODO, tasks, todolist, yaml, yml );
 	grid                 = ( css, css.erb, scss, sass, less, sql );
 	tree_structure       = ( dot, rl, proto, capnp );
-	config_file          = ( conf, htaccess, config, gitconfig, gitignore, gitmodules, ini, cfg, capfile, ssh_config, sshd_config, tm_properties, tmproperties, ant.xml, build.xml, pro, pri, cmake, cmakelists.txt, Makefile, gnumakefile, ocamlmakefile, pom.xml, cm, Rakefile, rake, target, portfile, gemspec, gemfile, ninja, project.clj, xcodeproj );
+	config_file          = ( conf, htaccess, config, gitconfig, gitignore, gitmodules, ini, cfg, capfile, ssh_config, sshd_config, tm_properties, tmproperties, ant.xml, build.xml, pro, pri, cmake, cmakelists.txt, Makefile, gnumakefile, ocamlmakefile, pom.xml, cm, Rakefile, rake, target, portfile, gemspec, gemfile, ninja, project.clj, xcodeproj, Cargo.toml );
 
 	c                    = ( c, cc, cxx, cpp, 'c++' );
 	javascript           = ( js, htc, jsx, jsfl, js.erb );


### PR DESCRIPTION
This is a build system for Rust projects, added after a conversation in a [rust bundle pull request](https://github.com/carols10cents/rust.tmbundle/pull/10). Activates on presence of a `Cargo.toml` file, will be used to trigger custom Run/Build/etc. commands.

Patch released into the public domain.