### PR TITLE
Revert "Disable unused-local-typedef warning for `sparsehash`"

### DIFF
--- a/Shared/PCH/prelude.cc
+++ b/Shared/PCH/prelude.cc
@@ -22,10 +22,6 @@
 #include <thread>
 #include <boost/crc.hpp>
 #include <boost/variant.hpp>
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
 #include <sparsehash/dense_hash_map>
-#pragma clang diagnostic pop
 
 #endif /* end of include guard: PRELUDE_CC_PCH_U5CKEP2N */


### PR DESCRIPTION
This reverts commit 2c6ad9b391a82e5334feb139eb53bea8b21e92b9.

Upstream released a new version, which resolved the warnings this commit meant to suppress.

It's available in brew.