### PR TITLE
Add "Commit and Continue" button to the commit window

### DIFF
--- a/Applications/commit/src/commit.mm
+++ b/Applications/commit/src/commit.mm
@@ -33,7 +33,12 @@ static double const AppVersion = 1.0;
 		fprintf(stderr, "%s", [err UTF8String]);
 
 	if(NSString* out = someOptions[kOakCommitWindowStandardOutput])
+	{
 		fprintf(stdout, "%s", [out UTF8String]);
+
+		if([someOptions[kOakCommitWindowContinue] boolValue])
+			fprintf(stdout, "TM_SCM_COMMIT_CONTINUE=1\n");
+	}
 
 	_returnCode = [someOptions[kOakCommitWindowReturnCode] intValue];
 

--- a/Frameworks/CommitWindow/src/CommitWindow.h
+++ b/Frameworks/CommitWindow/src/CommitWindow.h
@@ -7,6 +7,7 @@ static NSString* const kOakCommitWindowEnvironment          = @"environment";
 static NSString* const kOakCommitWindowStandardOutput       = @"stdout";
 static NSString* const kOakCommitWindowStandardError        = @"stderr";
 static NSString* const kOakCommitWindowReturnCode           = @"returnCode";
+static NSString* const kOakCommitWindowContinue             = @"continue";
 
 @protocol OakCommitWindowClientProtocol <NSObject>
 - (void)connectFromServerWithOptions:(NSDictionary*)someOptions;

--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -117,6 +117,7 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 @property (nonatomic) OakCommitWindow*                   retainedSelf;
 
 @property (nonatomic, readonly) BOOL                     rebaseInProgress;
+@property (nonatomic, readonly) BOOL                     amend;
 @end
 
 @implementation OakCommitWindow
@@ -146,7 +147,7 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 		self.window.releasedWhenClosed = NO;
 		self.window.frameAutosaveName  = @"Commit Window";
 
-		_commitButton = OakCreateButton(@"Commit", NSRoundedBezelStyle);
+		_commitButton = OakCreateButton([self commitTitle], NSRoundedBezelStyle);
 		_commitButton.action                    = @selector(performCommit:);
 		_commitButton.keyEquivalent             = @"\r";
 		_commitButton.keyEquivalentModifierMask = NSCommandKeyMask;
@@ -229,6 +230,11 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 
 	if(self.rebaseInProgress)
 		[NSEvent removeMonitor:_eventMonitor];
+}
+
+- (NSString*)commitTitle
+{
+	return self.amend ? @"Amend" : @"Commit";
 }
 
 - (NSDictionary*)allViews
@@ -440,6 +446,8 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 	{
 		if([arg isEqualToString:@"--rebase-in-progress"])
 			_rebaseInProgress = YES;
+		else if([arg isEqualToString:@"--amend"])
+			_amend = YES;
 		else if([optionKeys containsObject:arg])
 		{
 			if(NSString* value = [enumerator nextObject])
@@ -490,7 +498,7 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 			if(item.commit)
 				totalFilesToCommit += 1;
 		}
-		self.commitButtonCurrentBaseTitle = totalFilesToCommit == 1 ? [NSString stringWithFormat:@"Commit %lu File", totalFilesToCommit] : [NSString stringWithFormat:@"Commit %lu Files", totalFilesToCommit];
+		self.commitButtonCurrentBaseTitle = [NSString stringWithFormat:@"%@ %lu File%s", [self commitTitle], totalFilesToCommit, totalFilesToCommit == 1 ? "" : "s"];
 		self.commitButton.title = [self buildCommitButtonSuffix];
 	}
 }


### PR DESCRIPTION
The use case for this feature is when an interactive rebase is in
progress and be able to, in one command, amend the current commit
and continue with the rebase.

By default, if the --rebase-in-progress flag is passed when the
"commit" command is invoked the commit button will be in a
"commit and continue" state. This is indicated by the title of the
commit button now being "Commit & Continue". If the option (⌥) key
is being hold down the state will revert back to the standard "commit"
state and the title will change to "Continue".

If the butten was clicked when it was in the "commit and continue"
state the "commit" command will print "TM_SCM_COMMIT_CONTINUE=1"
(without the quotes) to stdout as the last line. If the button was
clicked when it was in the standard "commit" state the output may
contain "TM_SCM_COMMIT_CONTINUE=0", or the "TM_SCM_COMMIT_CONTINUE"
string will be absent