### PR TITLE
Use panel language unless spellingLanguage is specified

### DIFF
--- a/Applications/TextMate/src/AppController Menus.mm
+++ b/Applications/TextMate/src/AppController Menus.mm
@@ -97,6 +97,17 @@ OAK_DEBUG_VAR(AppController_Menus);
 		ordered.emplace(to_s(str ?: lang), lang);
 	}
 
+	NSString* systemSpellingLanguage;
+	if ([spellChecker automaticallyIdentifiesLanguages])
+		systemSpellingLanguage = @"Automatic by Language";
+	else
+	{
+		systemSpellingLanguage = (NSString*)CFBridgingRelease(CFLocaleCopyDisplayNameForPropertyValue(CFLocaleGetSystem(), kCFLocaleIdentifier, (__bridge CFStringRef)[spellChecker language]));
+	}
+	NSMenuItem* menuItem = [aMenu addItemWithTitle:[NSString stringWithFormat:@"System (%@)", systemSpellingLanguage] action:@selector(takeSpellingLanguageFrom:) keyEquivalent:@""];
+	D(DBF_AppController_Menus, bug("Represented Object: "" (System)\n"););
+	menuItem.representedObject = @"";
+
 	for(auto const& it : ordered)
 	{
 		D(DBF_AppController_Menus, bug("Add Item: %s\n", it.first.c_str()););

--- a/Frameworks/buffer/src/buffer.cc
+++ b/Frameworks/buffer/src/buffer.cc
@@ -11,7 +11,7 @@ OAK_DEBUG_VAR(Buffer_Parsing);
 
 namespace ng
 {
-	buffer_t::buffer_t (char const* str) : _grammar_callback(*this), _revision(0), _next_revision(1), _spelling_language("en")
+	buffer_t::buffer_t (char const* str) : _grammar_callback(*this), _revision(0), _next_revision(1), _spelling_language("")
 	{
 		_meta_data.push_back((_symbols = std::make_shared<symbols_t>()).get());
 		_meta_data.push_back((_marks = std::make_shared<marks_t>()).get());

--- a/Frameworks/buffer/tests/t_buffer.mm
+++ b/Frameworks/buffer/tests/t_buffer.mm
@@ -108,6 +108,7 @@ void test_spelling ()
 {
 	ng::buffer_t buf;
 	buf.set_grammar(TestGrammarItem);
+	buf.set_spelling_language("en");
 	buf.set_live_spelling(true);
 	buf.insert(0, "myfo god\nthat ibs nice\nlamere check\n");
 	buf.bump_revision();
@@ -125,6 +126,7 @@ void test_spelling_2 ()
 {
 	ng::buffer_t buf;
 	buf.set_grammar(TestGrammarItem);
+	buf.set_spelling_language("en");
 	buf.set_live_spelling(true);
 	buf.insert(0, "it mq xy");
 	buf.bump_revision();

--- a/Frameworks/document/src/document.cc
+++ b/Frameworks/document/src/document.cc
@@ -700,7 +700,7 @@ namespace document
 		}
 
 		settings_t const settings = settings_for_path(virtual_path(), file_type(), path::parent(_path), document_variables());
-		_buffer->set_spelling_language(settings.get(kSettingsSpellingLanguageKey, "en"));
+		_buffer->set_spelling_language(settings.get(kSettingsSpellingLanguageKey, ""));
 		_buffer->set_live_spelling(settings.get(kSettingsSpellCheckingKey, false));
 
 		D(DBF_Document, bug("done\n"););

--- a/Frameworks/ns/src/spellcheck.h
+++ b/Frameworks/ns/src/spellcheck.h
@@ -30,9 +30,9 @@ namespace ns
 		std::shared_ptr<helper_t> _helper;
 	};
 
-	PUBLIC std::vector<ns::range_t> spellcheck (char const* first, char const* last, std::string const& language = "en", spelling_tag_t const& tag = spelling_tag_t());
-	PUBLIC bool is_misspelled (char const* first, char const* last, std::string const& language = "en", spelling_tag_t const& tag = spelling_tag_t());
-	inline bool is_misspelled (std::string const& str, std::string const& language = "en", spelling_tag_t const& tag = spelling_tag_t()) { return is_misspelled(str.data(), str.data() + str.size(), language, tag); }
+	PUBLIC std::vector<ns::range_t> spellcheck (char const* first, char const* last, std::string const& language = "", spelling_tag_t const& tag = spelling_tag_t());
+	PUBLIC bool is_misspelled (char const* first, char const* last, std::string const& language = "", spelling_tag_t const& tag = spelling_tag_t());
+	inline bool is_misspelled (std::string const& str, std::string const& language = "", spelling_tag_t const& tag = spelling_tag_t()) { return is_misspelled(str.data(), str.data() + str.size(), language, tag); }
 
 } /* ns */
 

--- a/Frameworks/ns/src/spellcheck.mm
+++ b/Frameworks/ns/src/spellcheck.mm
@@ -35,7 +35,7 @@ namespace ns
 	_OutputIter spellcheck (char const* first, char const* last, std::string const& language, long int tag, size_t offset, _OutputIter out)
 	{
 		NSSpellChecker* spellChecker = [NSSpellChecker sharedSpellChecker];
-		NSString* lang               = spellChecker.automaticallyIdentifiesLanguages ? nil : [NSString stringWithCxxString:language];
+		NSString* lang               = language.length() ? [NSString stringWithCxxString:language] : nil;
 		NSString* str                = [NSString stringWithUTF8String:first length:last - first];
 		NSRange range                = [spellChecker checkSpellingOfString:str startingAt:0 language:lang wrap:NO inSpellDocumentWithTag:tag wordCount:NULL];
 

--- a/Frameworks/ns/tests/t_spellcheck.mm
+++ b/Frameworks/ns/tests/t_spellcheck.mm
@@ -4,15 +4,14 @@
 void setup ()
 {
 	NSApplicationLoad();
-	NSSpellChecker* spellChecker = [NSSpellChecker sharedSpellChecker];
-	spellChecker.automaticallyIdentifiesLanguages = NO;
+	[NSSpellChecker sharedSpellChecker];
 }
 
 void test_spellcheck ()
 {
 	std::string const str = "This is mispelled and agan.";
 
-	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length());
+	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length(), "en");
 	OAK_ASSERT_EQ(ranges.size(), 2);
 	OAK_ASSERT_EQ(ranges[0].first,  8);
 	OAK_ASSERT_EQ(ranges[0].last,  17);
@@ -22,15 +21,15 @@ void test_spellcheck ()
 
 void test_misspelled ()
 {
-	OAK_ASSERT_EQ(ns::is_misspelled("convinciable"), true);
-	OAK_ASSERT_EQ(ns::is_misspelled("convincible"), false);
+	OAK_ASSERT_EQ(ns::is_misspelled(std::string("convinciable"), "en"), true);
+	OAK_ASSERT_EQ(ns::is_misspelled(std::string("convincible"), "en"), false);
 }
 
 void test_newlines_1 ()
 {
 	std::string const str = "my(my)\n me";
 
-	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length());
+	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length(), "en");
 	OAK_ASSERT_EQ(ranges.size(), 0);
 }
 
@@ -38,7 +37,7 @@ void test_newlines_2 ()
 {
 	std::string const str = "my(my)\n qwong";
 
-	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length());
+	std::vector<ns::range_t> ranges = ns::spellcheck(str.data(), str.data() + str.length(), "en");
 	OAK_ASSERT_EQ(ranges.size(), 1);
 	OAK_ASSERT_EQ(ranges[0].first, 8);
 	OAK_ASSERT_EQ(ranges[0].last, 13);

--- a/Frameworks/settings/src/settings.cc
+++ b/Frameworks/settings/src/settings.cc
@@ -293,6 +293,9 @@ std::vector<setting_info_t> settings_info_for_path (std::string const& path, sco
 
 static std::string quote_string (std::string const& src)
 {
+	if(src.length() == 0)
+		return "''";
+
 	if(src.find_first_of("'\n\\ ") == std::string::npos)
 		return src;
 


### PR DESCRIPTION
This partially reverts changes of 3fdc72b93af0167e234c48314658d702f65a8a5f: Support spell checking being “automatic by language”.

Before 3fdc72b `spellingLanguage` .tm_properties setting (default "en") was the only way to set spelling language for file (buffer). English was default language for all files. 3fdc72b introduced change that when “automatic by language” was selected in system's spelling panel then TextMate was ignoring `spellingLanguage` setting and was using automatic by language.

However because “automatic by language” is default on OS X, effectively 3fdc72b makes `spellingLanguage` setting no longer effective. To make it work one needs to set explicit spelling language either in System Preferences or in spelling panel upon each TextMate run (since this is getting reset after application restart) - which is counter-intuitive, can be treated as regression and it is vaguely described in ChangeLog:

 * Support spell checking being “automatic by language”. This is set via the
   spelling panel.

This change presents alternative approach, introducing new empty `spellingLanguage` setting "" (which is now default), which makes use system panel language setting, including “automatic by language”.

From now on all files will be checked against system panel selected language (or automatic), unless .tm_properties project specifies explicitly language for given file using, eg.:

    [ locale-en_US.ini ]
    spellingLanguage = en_US

    [ locale-pl_PL.ini ]
    spellingLanguage = pl_PL

Or automatically depending on file name:

    [ locale-*.ini ]
    spellingLanguage = '${TM_FILEPATH/^.*locale-([a-z]+_[A-Z]+).*$/$1/}'