### PR TITLE
Break on comments extending selection to paragraph

### DIFF
--- a/Frameworks/selection/src/selection.cc
+++ b/Frameworks/selection/src/selection.cc
@@ -582,10 +582,12 @@ namespace ng
 			{
 				if(line == 0)
 					return 0;
-
 				for(size_t n = line-1; n > 0; --n)
 				{
-					std::string const& line = buffer.substr(buffer.begin(n), buffer.end(n));
+					size_t eol = buffer.end(n);
+					if(plist::is_true(bundles::value_for_setting("excludeFromParagraphSelection", buffer.scope(eol-1))))
+						return buffer.begin(n+1);
+					std::string const& line = buffer.substr(buffer.begin(n), eol);
 					if(text::is_blank(line.data(), line.data() + line.size()))
 						return buffer.begin(n+1);
 				}
@@ -597,7 +599,10 @@ namespace ng
 			{
 				for(size_t n = line+1; n < buffer.lines(); ++n)
 				{
-					std::string const& line = buffer.substr(buffer.begin(n), buffer.end(n));
+					size_t eol = buffer.end(n);
+					if(plist::is_true(bundles::value_for_setting("excludeFromParagraphSelection", buffer.scope(eol-1))))
+						return buffer.begin(n);
+					std::string const& line = buffer.substr(buffer.begin(n), eol);
 					if(text::is_blank(line.data(), line.data() + line.size()))
 						return buffer.begin(n);
 				}


### PR DESCRIPTION
Previously when reformatting paragraph comment lines were selected as paragraph
lines, this have led to mixing comment content into reformatted paragraph
content breaking the syntax of reformatted code, eg.:

~~~bash
some very long ... line of text
# some comment
some other long ... line of text
~~~

As an effect we got:

~~~bash
some very long ...
... text # some comment some other ...
... line of text
~~~

The problem described above was especially visible when using <kbd>⌃Q</kbd> to Reformat
block of Git commit message, when below of the typed text there was a Git
default comment. Also this problem could be noticeable by authors using LaTeX.

This change checks whether a candidate line for paragraph extension has a
"comment.line" scope at the end and breaks upon such trailing line comment.

Doing Select Paragraph <kbd>⌃⌥P</kbd> again will select the comment as well.

@sorbits I know this solution is not perfect and quite hacky, but I couldn't think of anything more generic.