### PR TITLE
Add prototype for bug macro

### DIFF
--- a/Frameworks/OakDebug/src/OakDebugLog.h
+++ b/Frameworks/OakDebug/src/OakDebugLog.h
@@ -44,7 +44,7 @@ struct PUBLIC OakDebugBaseClass
 
 #define OAK_DEBUG(expr)
 #define OAK_DEBUG_VAR(name) ;
-#define bug
+#define bug(format, args...)
 #define D(flag, code) ;
 
 #endif


### PR DESCRIPTION
Compiling code that uses the `bug` macro
while the `NDEBUG` symbol is defined
(which it is by default)
results in “expression result unused” warnings
for each argument to the `bug` call.

This change adds the parameter declaration
from the debug version to the non-debug version,
which silences these warnings.