### PR TITLE
Fixes a crash on "force touch"

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -3728,8 +3728,11 @@ static scope::context_t add_modifiers_to_scope (scope::context_t scope, NSUInteg
 	NSRect rect = layout->rect_at_index(range.min(), false, true);
 	NSPoint pos = NSMakePoint(NSMinX(rect), NSMaxY(rect));
 
-	NSAttributedString* str = [self attributedSubstringForProposedRange:[self nsRangeForRange:range] actualRange:nullptr];
-	[self showDefinitionForAttributedString:str atPoint:pos];
+	NSRange nsRange = [self nsRangeForRange:range];
+	if (nsRange.length > 0) {
+		NSAttributedString* str = [self attributedSubstringForProposedRange:nsRange actualRange:nullptr];
+		[self showDefinitionForAttributedString:str atPoint:pos];
+	}
 }
 
 - (void)pressureChangeWithEvent:(NSEvent*)anEvent


### PR DESCRIPTION
This PR fixes a crash which occurs when one is doing a "force touch" on a trackpad when the cursor is over an empty area of a plain text document.

It seems that the "showDefinitionForAttributedString:" can accept a nil argument, but not an empty string. The inserted test is preventing the call when the extracted string contains no characters.