### PR TITLE
Ensure path exists when adding document to Recent menu

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentOpenHelper.mm
+++ b/Frameworks/DocumentWindow/src/DocumentOpenHelper.mm
@@ -114,7 +114,7 @@ namespace
 - (void)didOpenDocument:(document::document_ptr const&)aDocument
 {
 	D(DBF_DocumentController_OpenHelper, bug("%s\n", aDocument->display_name().c_str()););
-	if(aDocument->recent_tracking() && aDocument->path() != NULL_STR)
+	if(aDocument->recent_tracking() && path::exists(aDocument->path()))
 		[[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:[NSString stringWithCxxString:aDocument->path()]]];
 	self.callback(NULL_STR, oak::uuid_t());
 }

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -87,7 +87,7 @@ struct document_view_callback_t : document::document_t::callback_t
 			self.statusBar.softTabs = document->buffer().indent().soft_tabs();
 		}
 
-		if(document->recent_tracking() && document->path() != NULL_STR)
+		if(document->recent_tracking() && path::exists(document->path()))
 		{
 			if(event == did_save || event == did_change_path || (event == did_change_open_status && document->is_open()))
 				[[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:[NSString stringWithCxxString:document->path()]]];


### PR DESCRIPTION
It's possible that the path on the document is set even though it does not exist on disk. E.g., when using `mate` to create a new document from the command line.

I tried to handle this in `mate.cc` by treating such files as temporaries and not tracking them, but then they would not be added to the Recent menu after saving. 