### PR TITLE
CommitWindow: Force update of constraints after animation is completed

### DIFF
--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -384,6 +384,7 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 			[contentView addConstraint:_documentViewHeightConstraint];
 			_scrollViewHeightConstraint.animator.constant = kOakCommitWindowTableViewHeight;
 		} completionHandler:^{
+			[self.window displayIfNeeded];
 			[contentView removeConstraint:_documentViewHeightConstraint];
 			_documentViewHeightConstraint = [NSLayoutConstraint constraintWithItem:_documentView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1 constant:kOakCommitWindowMinimumDocumentViewHeight];
 			[contentView addConstraint:_documentViewHeightConstraint];


### PR DESCRIPTION
This is necessary to prevent resizing of the document view when removing and then immediately adding a new constraint to the document view.

I don't recall seeing this issue before so it may just occur on 10.11.