### PR TITLE
RFC: Jump to marks

### DIFF
--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15E27e" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1070" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">

--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -836,6 +836,17 @@ CA
                                 <menu key="submenu" title="Go to Bookmark" id="595"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="439"/>
+                            <menuItem title="Jump To Next Mark" keyEquivalent="&gt;" id="gGW-Hn-MX6">
+                                <connections>
+                                    <action selector="jumpToNextMark:" target="-1" id="999"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Jump To Previous Mark" keyEquivalent="&lt;" id="5Mq-52-EUe">
+                                <connections>
+                                    <action selector="jumpToPreviousMark:" target="-1" id="998"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="HcX-yL-1Rc"/>
                             <menuItem title="Scroll" id="429">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Scroll" id="430">

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -479,6 +479,16 @@ private:
 		ng::buffer_t const& buf = document->buffer();
 		[aMenuItem setTitle:buf.get_marks(buf.begin(lineNumber), buf.eol(lineNumber), document::kBookmarkIdentifier).empty() ? @"Set Bookmark" : @"Remove Bookmark"];
 	}
+	else if([aMenuItem action] == @selector(goToNextBookmark:) || [aMenuItem action] == @selector(goToPreviousBookmark:))
+	{
+		auto const& buf = document->buffer();
+		return buf.get_marks(0, buf.size(), document::kBookmarkIdentifier).empty() ? NO : YES;
+	}
+	else if([aMenuItem action] == @selector(jumpToNextMark:) || [aMenuItem action] == @selector(jumpToPreviousMark:))
+	{
+		auto const& buf = document->buffer();
+		return buf.get_marks(0, buf.size()).empty() ? NO : YES;
+	}
 	return YES;
 }
 

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -918,6 +918,30 @@ private:
 	[[NSNotificationCenter defaultCenter] postNotificationName:GVColumnDataSourceDidChange object:self];
 }
 
+// ========================
+// = Jump To Mark Actions =
+// ========================
+
+- (IBAction)jumpToNextMark:(id)sender
+{
+	text::selection_t sel(to_s(textView.selectionString));
+
+	ng::buffer_t const& buf = document->buffer();
+	std::pair<size_t, std::string> const& pair = buf.next_mark(buf.convert(sel.last().max()));
+	if(pair.second != NULL_STR)
+		textView.selectionString = [NSString stringWithCxxString:buf.convert(pair.first)];
+}
+
+- (IBAction)jumpToPreviousMark:(id)sender
+{
+	text::selection_t sel(to_s(textView.selectionString));
+
+	ng::buffer_t const& buf = document->buffer();
+	std::pair<size_t, std::string> const& pair = buf.prev_mark(buf.convert(sel.last().max()));
+	if(pair.second != NULL_STR)
+		textView.selectionString = [NSString stringWithCxxString:buf.convert(pair.first)];
+}
+
 // =================
 // = Accessibility =
 // =================

--- a/Frameworks/buffer/src/buffer.cc
+++ b/Frameworks/buffer/src/buffer.cc
@@ -332,7 +332,9 @@ namespace ng
 	std::multimap<size_t, std::pair<std::string, std::string>> buffer_t::get_marks (size_t from, size_t to) const { return _marks->get_range(from, to); }
 	std::map<size_t, std::string> buffer_t::get_marks (size_t from, size_t to, std::string const& markType) const { return _marks->get_range(from, to, markType); }
 	std::pair<size_t, std::string> buffer_t::next_mark (size_t index, std::string const& markType) const          { return _marks->next(index, markType); }
+	std::pair<size_t, std::string> buffer_t::next_mark (size_t index) const                                       { return _marks->next(index); }
 	std::pair<size_t, std::string> buffer_t::prev_mark (size_t index, std::string const& markType) const          { return _marks->prev(index, markType); }
+	std::pair<size_t, std::string> buffer_t::prev_mark (size_t index) const                                       { return _marks->prev(index); }
 
 	// ========
 	// = to_s =

--- a/Frameworks/buffer/src/buffer.h
+++ b/Frameworks/buffer/src/buffer.h
@@ -133,8 +133,10 @@ namespace ng
 		std::string get_mark (size_t index, std::string const& markType) const;
 		std::multimap<size_t, std::pair<std::string, std::string>> get_marks (size_t from, size_t to) const;
 		std::map<size_t, std::string> get_marks (size_t from, size_t to, std::string const& markType) const;
-		std::pair<size_t, std::string> next_mark (size_t index, std::string const& markType = NULL_STR) const;
-		std::pair<size_t, std::string> prev_mark (size_t index, std::string const& markType = NULL_STR) const;
+		std::pair<size_t, std::string> next_mark (size_t index, std::string const& markType) const;
+		std::pair<size_t, std::string> next_mark (size_t index) const;
+		std::pair<size_t, std::string> prev_mark (size_t index, std::string const& markType) const;
+		std::pair<size_t, std::string> prev_mark (size_t index) const;
 
 		void wait_for_repair ();
 

--- a/Frameworks/buffer/src/marks.cc
+++ b/Frameworks/buffer/src/marks.cc
@@ -37,6 +37,33 @@ namespace ng
 		return _marks.find(markType)->second.find(index)->second;
 	}
 
+	std::pair<size_t, std::string> marks_t::next (size_t index) const
+	{
+		std::vector<std::pair<size_t, std::string>> candidates;
+		for(auto const& m : _marks)
+		{
+			if(m.second.size() == 1)
+			{
+				candidates.push_back(*m.second.begin());
+			}
+			else
+			{
+				auto it = m.second.upper_bound(index);
+				candidates.push_back(*(it == m.second.end() ? m.second.begin() : it));
+			}
+		}
+
+		if(candidates.empty())
+			return std::make_pair(0, NULL_STR);
+		else if(candidates.size() == 1)
+			return candidates.front();
+
+		std::sort(candidates.begin(), candidates.end());
+		auto it = std::upper_bound(candidates.begin(), candidates.end(), index, [](size_t index, std::pair<size_t, std::string> const& mark){ return mark.first > index; });
+
+		return *(it == candidates.end() ? candidates.begin() : it);
+	}
+
 	std::pair<size_t, std::string> marks_t::next (size_t index, std::string const& markType) const
 	{
 		std::map<std::string, tree_t>::const_iterator m = _marks.find(markType);
@@ -50,6 +77,33 @@ namespace ng
 
 		tree_t::iterator it = m->second.upper_bound(index);
 		return *(it == m->second.end() ? m->second.begin() : it);
+	}
+
+	std::pair<size_t, std::string> marks_t::prev (size_t index) const
+	{
+		std::vector<std::pair<size_t, std::string>> candidates;
+		for(auto const& m : _marks)
+		{
+			if(m.second.size() == 1)
+			{
+				candidates.push_back(*m.second.begin());
+			}
+			else
+			{
+				auto it = m.second.lower_bound(index);
+				candidates.push_back(*(--(it == m.second.begin() ? m.second.end() : it)));
+			}
+		}
+
+		if(candidates.empty())
+			return std::make_pair(0, NULL_STR);
+		else if(candidates.size() == 1)
+			return candidates.front();
+
+		std::sort(candidates.begin(), candidates.end());
+		auto it = std::lower_bound(candidates.begin(), candidates.end(), index, [](std::pair<size_t, std::string> const& mark, size_t index){ return mark.first < index; });
+
+		return *(--(it == candidates.begin() ? candidates.end() : it));
 	}
 
 	std::pair<size_t, std::string> marks_t::prev (size_t index, std::string const& markType) const

--- a/Frameworks/buffer/src/meta_data.h
+++ b/Frameworks/buffer/src/meta_data.h
@@ -44,7 +44,9 @@ namespace ng
 		std::multimap<size_t, std::pair<std::string, std::string>> get_range (size_t from, size_t to) const;
 		std::map<size_t, std::string> get_range (size_t from, size_t to, std::string const& markType) const;
 
+		std::pair<size_t, std::string> next (size_t index) const;
 		std::pair<size_t, std::string> next (size_t index, std::string const& markType) const;
+		std::pair<size_t, std::string> prev (size_t index) const;
 		std::pair<size_t, std::string> prev (size_t index, std::string const& markType) const;
 
 	private:


### PR DESCRIPTION
This essentially add keyboard shortcuts to jump to next/previous mark, regardless if it's a bookmark or not. I do not know if these are the best shortcuts to use. Xcode uses <kbd>⌘</kbd> + <kbd>' </kbd> and  <kbd>⌘</kbd> + <kbd>" </kbd>, but those are already being use by other bundles. And I couldn't find examples from other apps that have a similar feature. Any suggestions?
