### PR TITLE
Add a couple of explicit link dependencies

### DIFF
--- a/Applications/commit/target
+++ b/Applications/commit/target
@@ -1,1 +1,2 @@
 SOURCES = src/*.mm
+LINK = CommitWindow

--- a/Frameworks/Find/target
+++ b/Frameworks/Find/target
@@ -2,5 +2,5 @@ SOURCES      = src/*.{cc,mm}
 TESTS        = tests/*.cc
 EXPORT       = src/Find.h src/scan_path.h
 CP_Resources = resources/*
-LINK        += text editor io ns OakAppKit OakFoundation regexp scope
+LINK        += text editor io ns OakAppKit OakFoundation Preferences regexp scope
 FRAMEWORKS   = Cocoa


### PR DESCRIPTION
While looking into this [issue](http://lists.macromates.com/textmate/2016-February/039236.html) on the mailing list, I noticed we didn't have an explicit link for the CommitWindow framework. I am not sure if this is an actual problem (or really necessary) as I was unable to reproduce the original error. However, while performing a clean build I encounter a similar issue where it was complaining of `Preferences/Keys.h` not being found when compiling `FindWindowController.mm`. In both case we were missing a linking dependency.