### PR TITLE
fixup! Ignore /usr/bin/git if /usr/bin/xcode-select -p fails

### DIFF
--- a/Frameworks/scm/src/drivers/api.cc
+++ b/Frameworks/scm/src/drivers/api.cc
@@ -41,7 +41,7 @@ namespace scm
 			{
 				if(path == "/usr/bin/git")
 				{
-					std::string const xcodePath = io::exec("/usr/bin/xcode-select", "-p");
+					std::string const xcodePath = io::exec("/usr/bin/xcode-select", "-p", NULL);
 					if(!path::is_directory(text::trim(xcodePath, "\n")))
 					{
 						fprintf(stderr, "*** ignore ‘%s’ because it appears to be a shim and Xcode is not installed\n", path.c_str());


### PR DESCRIPTION
The missing NULL was causing TextMate to crash.