### PR TITLE
Allow gutter fontName to be set independently of editor fontName

### DIFF
--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -23,6 +23,7 @@
 OAK_DEBUG_VAR(OakDocumentView);
 
 static NSString* const kUserDefaultsLineNumberScaleFactorKey = @"lineNumberScaleFactor";
+static NSString* const kUserDefaultsLineNumberFontNameKey = @"lineNumberFontName";
 
 static NSString* const kBookmarksColumnIdentifier = @"bookmarks";
 static NSString* const kFoldingsColumnIdentifier  = @"foldings";
@@ -263,9 +264,10 @@ private:
 - (void)updateGutterViewFont:(id)sender
 {
 	CGFloat const scaleFactor = [[NSUserDefaults standardUserDefaults] floatForKey:kUserDefaultsLineNumberScaleFactorKey] ?: 0.8;
+	NSString* lineNumberFontName = [[NSUserDefaults standardUserDefaults] objectForKey:kUserDefaultsLineNumberFontNameKey] ?: [textView.font fontName];
 
 	gutterImages = nil; // force image sizes to be recalculated
-	gutterView.lineNumberFont = [NSFont fontWithName:[textView.font fontName] size:round(scaleFactor * [textView.font pointSize] * textView.fontScaleFactor / 100)];
+	gutterView.lineNumberFont = [NSFont fontWithName:lineNumberFontName size:round(scaleFactor * [textView.font pointSize] * textView.fontScaleFactor / 100)];
 	[gutterView reloadData:self];
 }
 


### PR DESCRIPTION
I like Xcode’s gutter font (Xcode Digits) and I wanted to use the font in TextMate. I wasn’t sure where the best place is for a setting like this, but since the scale factor is already in `NSUserDefaults`, saving the gutter font name there as well made sense to me.

Xcode Digits lives here:
![Xcode Digits](https://cloud.githubusercontent.com/assets/13781/16174676/0ad98e98-3582-11e6-94d2-04c135acc383.png)