### PR TITLE
Go menu changes

### DIFF
--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -1038,8 +1038,8 @@ CQ
                         </items>
                     </menu>
                 </menuItem>
-                <menuItem title="Go" id="299">
-                    <menu key="submenu" title="Go" id="300">
+                <menuItem title="File Browser" id="299">
+                    <menu key="submenu" title="File Browser" id="300">
                         <items>
                             <menuItem title="Back" id="545">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -892,6 +892,13 @@ CA
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="804"/>
+                            <menuItem title="Go to Related File" keyEquivalent="" id="303">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="goToRelatedFile:" target="-1" id="305"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="8Tf-mh-Vpb"/>
                             <menuItem title="Move Focus to File Browser" id="803">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 CQ
@@ -1034,13 +1041,6 @@ CQ
                 <menuItem title="Go" id="299">
                     <menu key="submenu" title="Go" id="300">
                         <items>
-                            <menuItem title="Go to Related File" keyEquivalent="" id="303">
-                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
-                                <connections>
-                                    <action selector="goToRelatedFile:" target="-1" id="305"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="440"/>
                             <menuItem title="Back" id="545">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -125,6 +125,11 @@
                                     <action selector="openFavorites:" target="-1" id="610"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Quick Open…" keyEquivalent="t" id="301" userLabel="Quick Open…">
+                                <connections>
+                                    <action selector="goToFile:" target="-1" id="302"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Open Recent" id="124">
                                 <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="125">
                                     <items>
@@ -1029,11 +1034,6 @@ CQ
                 <menuItem title="Go" id="299">
                     <menu key="submenu" title="Go" id="300">
                         <items>
-                            <menuItem title="Go to File…" keyEquivalent="t" id="301">
-                                <connections>
-                                    <action selector="goToFile:" target="-1" id="302"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Go to Related File" keyEquivalent="" id="303">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
@@ -1260,8 +1260,8 @@ DQ
         </window>
         <customObject id="581" customClass="OakSubmenuController">
             <connections>
-                <outlet property="selectTabMenu" destination="384" id="593"/>
                 <outlet property="marksMenu" destination="595" id="597"/>
+                <outlet property="selectTabMenu" destination="384" id="593"/>
             </connections>
         </customObject>
         <customObject id="711" customClass="NSFontManager"/>

--- a/Applications/TextMate/resources/English.lproj/MainMenu.xib
+++ b/Applications/TextMate/resources/English.lproj/MainMenu.xib
@@ -1040,9 +1040,6 @@ CQ
                                     <action selector="goToRelatedFile:" target="-1" id="305"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Go to Tab" id="383">
-                                <menu key="submenu" title="Go to Tab" id="384"/>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="440"/>
                             <menuItem title="Back" id="545">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -1159,6 +1156,9 @@ CQ
                                     <action selector="selectPreviousTab:" target="-1" id="337"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Select Tab" id="383" userLabel="Select Tab">
+                                <menu key="submenu" title="Select Tab" id="384"/>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="333">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
@@ -1260,7 +1260,7 @@ DQ
         </window>
         <customObject id="581" customClass="OakSubmenuController">
             <connections>
-                <outlet property="goToMenu" destination="384" id="593"/>
+                <outlet property="selectTabMenu" destination="384" id="593"/>
                 <outlet property="marksMenu" destination="595" id="597"/>
             </connections>
         </customObject>

--- a/Applications/TextMate/src/AboutWindowController.mm
+++ b/Applications/TextMate/src/AboutWindowController.mm
@@ -426,7 +426,7 @@ static NSTextField* OakCreateTextField ()
 
 // ====================
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(![[self window] isKeyWindow])
 	{

--- a/Applications/TextMate/src/Favorites.mm
+++ b/Applications/TextMate/src/Favorites.mm
@@ -323,7 +323,7 @@ static NSUInteger const kOakSourceIndexFavorites      = 1;
 		self.sourceIndex = [sender tag];
 }
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(self.window.isKeyWindow)
 	{

--- a/Applications/TextMate/target
+++ b/Applications/TextMate/target
@@ -1,5 +1,5 @@
 SOURCES              = src/*.{cc,mm}
-CP_Resources         = resources/* icons/*.icns about/* @PrivilegedTool @mate @tm_query @commit
+CP_Resources         = resources/* icons/*.icns about/* @PrivilegedTool @mate @tm_query @commit @gtm
 CP_SharedSupport     = support/*
 CP_PlugIns           = @Dialog @Dialog2
 CP_Library/QuickLook = @TextMateQL

--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -2262,10 +2262,10 @@ namespace
 }
 
 // ===========================
-// = Go to Tab Menu Delegate =
+// = Select Tab Menu Delegate =
 // ===========================
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(![self.window isKeyWindow])
 	{

--- a/Frameworks/Find/src/Find.mm
+++ b/Frameworks/Find/src/Find.mm
@@ -550,9 +550,9 @@ NSString* const FFFindWasTriggeredByEnter = @"FFFindWasTriggeredByEnter";
 	_windowController.statusString = [NSString stringWithFormat:fmt, [_documentSearch searchString], [NSNumberFormatter localizedStringFromNumber:@(self.countOfMatches) numberStyle:NSNumberFormatterDecimalStyle]];
 }
 
-// ==================
-// = Go to… Submenu =
-// ==================
+// =======================
+// = Select Tab… Submenu =
+// =======================
 
 - (IBAction)takeSelectedPathFrom:(id)sender
 {
@@ -561,7 +561,7 @@ NSString* const FFFindWasTriggeredByEnter = @"FFFindWasTriggeredByEnter";
 		[_windowController.resultsViewController showResultNode:item.firstResultNode];
 }
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(self.countOfMatches == 0)
 	{

--- a/Frameworks/Find/src/FindWindowController.mm
+++ b/Frameworks/Find/src/FindWindowController.mm
@@ -329,7 +329,7 @@ static NSButton* OakCreateStopSearchButton ()
 - (void)menuNeedsUpdate:(NSMenu*)aMenu
 {
 	[aMenu removeAllItems];
-	[NSApp sendAction:@selector(updateGoToMenu:) to:nil from:aMenu];
+	[NSApp sendAction:@selector(updateSelectTabMenu:) to:nil from:aMenu];
 }
 
 - (NSDictionary*)allViews

--- a/Frameworks/OakAppKit/src/OakSubmenuController.h
+++ b/Frameworks/OakAppKit/src/OakSubmenuController.h
@@ -2,7 +2,7 @@
 
 @interface OakSubmenuController : NSObject <NSMenuDelegate>
 {
-	IBOutlet NSMenu* goToMenu;
+	IBOutlet NSMenu* selectTabMenu;
 	IBOutlet NSMenu* marksMenu;
 }
 @end

--- a/Frameworks/OakAppKit/src/OakSubmenuController.mm
+++ b/Frameworks/OakAppKit/src/OakSubmenuController.mm
@@ -25,7 +25,7 @@ OAK_DEBUG_VAR(OakSubmenuController);
 @implementation OakSubmenuController
 - (void)awakeFromNib
 {
-	[goToMenu setDelegate:self];
+	[selectTabMenu setDelegate:self];
 	[marksMenu setDelegate:self];
 }
 
@@ -40,14 +40,14 @@ OAK_DEBUG_VAR(OakSubmenuController);
 
 - (void)menuNeedsUpdate:(NSMenu*)aMenu
 {
-	[self updateMenu:aMenu withSelector:aMenu == goToMenu ? @selector(updateGoToMenu:) : @selector(updateBookmarksMenu:)];
+	[self updateMenu:aMenu withSelector:aMenu == selectTabMenu ? @selector(updateSelectTabMenu:) : @selector(updateBookmarksMenu:)];
 }
 
 - (BOOL)menuHasKeyEquivalent:(NSMenu*)aMenu forEvent:(NSEvent*)anEvent target:(id*)anId action:(SEL*)aSEL
 {
 	D(DBF_OakSubmenuController, bug("%s %s\n", to_s(anEvent).c_str(), [[aMenu description] UTF8String]););
 
-	if(aMenu != goToMenu)
+	if(aMenu != selectTabMenu)
 		return NO;
 
 	std::string const eventString = to_s(anEvent);
@@ -55,7 +55,7 @@ OAK_DEBUG_VAR(OakSubmenuController);
 		return NO;
 
 	NSMenu* dummy = [NSMenu new];
-	[self updateMenu:dummy withSelector:@selector(updateGoToMenu:)];
+	[self updateMenu:dummy withSelector:@selector(updateSelectTabMenu:)];
 	for(NSMenuItem* item in [dummy itemArray])
 	{
 		if(eventString == ns::create_event_string(item.keyEquivalent, item.keyEquivalentModifierMask))

--- a/Frameworks/OakFilterList/src/FileChooser.mm
+++ b/Frameworks/OakFilterList/src/FileChooser.mm
@@ -682,7 +682,7 @@ static path::glob_list_t globs_for_path (std::string const& path)
 	self.path = [_path stringByDeletingLastPathComponent];
 }
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(self.window.isKeyWindow)
 	{

--- a/Frameworks/OakFilterList/src/FileChooser.mm
+++ b/Frameworks/OakFilterList/src/FileChooser.mm
@@ -233,7 +233,7 @@ static path::glob_list_t globs_for_path (std::string const& path)
 		case kFileChooserOpenDocumentsSourceIndex:      src = @"Open Documents";                               break;
 		case kFileChooserUncommittedChangesSourceIndex: src = @"Uncommitted Documents";                        break;
 	}
-	self.window.title = [NSString stringWithFormat:@"Go to File — %@", src];
+	self.window.title = [NSString stringWithFormat:@"Quick Open — %@", src];
 }
 
 - (oak::uuid_t const&)currentDocument                       { return _currentDocument; }

--- a/Frameworks/Preferences/src/Preferences.mm
+++ b/Frameworks/Preferences/src/Preferences.mm
@@ -67,7 +67,7 @@ OAK_DEBUG_VAR(Preferences);
 	[self.windowController selectControllerAtIndex:index];
 }
 
-- (void)updateGoToMenu:(NSMenu*)aMenu
+- (void)updateSelectTabMenu:(NSMenu*)aMenu
 {
 	if(![self.windowController.window isKeyWindow])
 		return;


### PR DESCRIPTION
This PR implement the suggestions in #1327.

After interacting with it a little bit, I personally think the new menu layout is more intuitive. I moved _Go to Related File_ to the _Navigate_ menu. The motivation was based on Xcode's _Navigate_  → _Jump to Next Counterpart_ which has similar behavior, though I didn't rename it using the "Jump to" prefix since the other "Jump" items work within the current file and also after changing  the name of the _Go_ menu  to _File Browser_, the usage of "Go" seems less of a concern.

 The commits should be atomic so you can pick and choose. 