### PR TITLE
Pass our minimum deployment target to ibtool

### DIFF
--- a/bin/gen_build
+++ b/bin/gen_build
@@ -951,7 +951,7 @@ rule dsym
   description = Archive dSYM info for ‘$in’…
 
 rule compile_xib
-  command = xcrun ibtool --errors --warnings --notices --output-format human-readable-text --compile $out $in
+  command = xcrun ibtool --errors --warnings --notices --output-format human-readable-text --minimum-deployment-target $APP_MIN_OS --compile $out $in
   description = Compile xib ‘$in’…
 
 rule process_plist


### PR DESCRIPTION
Since we are making changes to the main.xib, I decided to dig into the cause of
```
warning: This file is set to build for a version older than the deployment target. Functionality may be limited. [9]
``` 
and found a few google results about CocoaPods experiencing similar issues and passing `--minimum-deployment-target` to `ibtool` to resolve it. It probably wasn't causing any problems or worth fixing, but it does make a clean build a little less noisy. 😉 Also, as I mentioned in the commit message, I don't think it will be necessary when we move the deployment target to 10.8 or higher.