### PR TITLE
Use non-deprecated method to load nib (10.8)

### DIFF
--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -725,7 +725,7 @@ private:
 - (IBAction)showTabSizeSelectorPanel:(id)sender
 {
 	if(!tabSizeSelectorPanel)
-		[NSBundle loadNibNamed:@"TabSizeSetting" owner:self];
+		[[NSBundle bundleForClass:[self class]] loadNibNamed:@"TabSizeSetting" owner:self topLevelObjects:NULL];
 	[tabSizeSelectorPanel makeKeyAndOrderFront:self];
 }
 


### PR DESCRIPTION
We can pass `NULL` to `topLevelObjects` since we have a strong IBOutlet to the NSPanel (our top-level object).