### PR TITLE
Refactor ODBEditorSuite to avoid FSRef API (10.8)

### DIFF
--- a/Applications/TextMate/src/ODBEditorSuite.cc
+++ b/Applications/TextMate/src/ODBEditorSuite.cc
@@ -1,4 +1,5 @@
 #include "ODBEditorSuite.h"
+#include <cf/cf.h>
 #include <document/collection.h>
 #include <oak/debug.h>
 #include <text/hexdump.h>
@@ -23,11 +24,24 @@ struct ae_record_t
 
 	std::string path () const
 	{
-		UInt8 buf[PATH_MAX];
-		std::string const& fsref = data();
-		if(noErr == FSRefMakePath((FSRef const*)&fsref[0], buf, sizeof(buf)))
-			return std::string((char*)buf);
-		return NULL_STR;
+		std::string res = NULL_STR;
+		AEDesc furlDesc;
+		if(noErr == AECoerceDesc(&value, typeFileURL, &furlDesc))
+		{
+			std::string buf(AEGetDescDataSize(&furlDesc), ' ');
+			AEGetDescData(&furlDesc, &buf[0], buf.size());
+			if(CFURLRef url = CFURLCreateWithBytes(kCFAllocatorDefault, (UInt8*)buf.data(), buf.size(), kCFStringEncodingUTF8, NULL))
+			{
+				if(CFStringRef path = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle))
+				{
+					res = cf::to_s(path);
+					CFRelease(path);
+				}
+				CFRelease(url);
+			}
+			AEDisposeDesc(&furlDesc);
+		}
+		return res;
 	}
 
 	ae_record_ptr record_at_index (size_t i, DescType type = typeWildCard)
@@ -79,8 +93,7 @@ namespace odb // wrap in namespace to avoid clashing with other callbacks named 
 		{
 			D(DBF_ODBEditorSuite, int c = htonl(eventId); bug("‘%.4s’\n", (char*)&c););
 
-			FSRef fsRef;
-			if(noErr == FSPathMakeRef((UInt8 const*)path.c_str(), &fsRef, NULL))
+			if(CFURLRef url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (UInt8*)path.c_str(), path.size(), false))
 			{
 				AEAddressDesc target;
 				std::string const& senderData = sender->data();
@@ -90,7 +103,12 @@ namespace odb // wrap in namespace to avoid clashing with other callbacks named 
 				AppleEvent event;
 				AECreateAppleEvent(kODBEditorSuite, eventId, &target, kAutoGenerateReturnID, kAnyTransactionID, &event);
 
-				AEPutParamPtr(&event, keyDirectObject, typeFSRef, &fsRef, sizeof(fsRef));
+				CFIndex byteCount;
+				CFStringRef urlString = CFURLGetString(url);
+				CFStringGetBytes(urlString, CFRangeMake(0, CFStringGetLength(urlString)), kCFStringEncodingUTF8, 0, false, NULL, 0, &byteCount);
+				AEPutParamPtr(&event, keyDirectObject, typeFileURL, CFStringGetCStringPtr(urlString, kCFStringEncodingUTF8), byteCount);
+				CFRelease(url);
+
 				if(token != NULL_STR)
 					AEPutParamPtr(&event, keySenderToken, typeWildCard, token.data(), token.size());
 


### PR DESCRIPTION
I have tested this using MarsEdit and it appears to be working correctly, though you may want to scrutinize it.

I attend to take care of the other usage of the FSRef API; however, that appears to be working around a bug in 10.8 where the deleting a symbolic link would delete the actual file and not the link. I believe this was resolve in 10.8.3, so maybe hold off on removing it until we go to 10.9. 