### PR TITLE
Manually release GCD objects in C++ libraries

### DIFF
--- a/Frameworks/document/src/merge.cc
+++ b/Frameworks/document/src/merge.cc
@@ -28,6 +28,7 @@ std::string merge (std::string const& oldContent, std::string const& myContent, 
 				perror("waitpid");
 		});
 		dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+		dispatch_release(group);
 
 		if(conflict)
 			*conflict = WIFEXITED(status) && WEXITSTATUS(status) != 0;

--- a/Frameworks/editor/src/editor.cc
+++ b/Frameworks/editor/src/editor.cc
@@ -435,6 +435,7 @@ namespace ng
 							perror("waitpid");
 					});
 					dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+					dispatch_release(group);
 				}
 
 				unlink(scriptPath.c_str());

--- a/Frameworks/io/src/exec.cc
+++ b/Frameworks/io/src/exec.cc
@@ -119,6 +119,7 @@ namespace io
 		});
 
 		dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+		dispatch_release(group);
 		D(DBF_IO_Exec, if(!error.empty()) bug("error from command: “%s”\n", error.c_str()););
 		return success ? output : NULL_STR;
 	}

--- a/Frameworks/network/src/tbz.cc
+++ b/Frameworks/network/src/tbz.cc
@@ -27,7 +27,10 @@ namespace network
 	tbz_t::~tbz_t ()
 	{
 		if(_group)
+		{
 			dispatch_group_wait(_group, DISPATCH_TIME_FOREVER);
+			dispatch_release(_group);
+		}
 	}
 
 	bool tbz_t::wait_for_tbz (std::string* output, std::string* error)

--- a/Frameworks/settings/src/track_paths.h
+++ b/Frameworks/settings/src/track_paths.h
@@ -62,7 +62,11 @@ private:
 		~track_fds_t ()
 		{
 			for(auto pair : _records)
+			{
 				dispatch_source_cancel(pair.second->source);
+				dispatch_release(pair.second->source);
+			}
+
 			_records.clear();
 		}
 
@@ -88,6 +92,7 @@ private:
 			if(pair != _records.end())
 			{
 				dispatch_source_cancel(pair->second->source);
+				dispatch_release(pair->second->source);
 				_records.erase(pair);
 			}
 		}


### PR DESCRIPTION
Since these are pure C++ libraries, they are not managed by ARC.