### PR TITLE
Use weak storage for GutterView's partnerView

### DIFF
--- a/Frameworks/OakTextView/src/GutterView.h
+++ b/Frameworks/OakTextView/src/GutterView.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSUInteger, GutterViewRowState) {
 @end
 
 @interface GutterView : NSView
-@property (nonatomic) IBOutlet NSView* partnerView;
+@property (nonatomic, weak) IBOutlet NSView* partnerView;
 @property (nonatomic) NSFont* lineNumberFont;
 @property (nonatomic, weak) id <GutterViewDelegate> delegate;
 @property (nonatomic) NSColor* foregroundColor;

--- a/Frameworks/OakTextView/src/GutterView.mm
+++ b/Frameworks/OakTextView/src/GutterView.mm
@@ -82,12 +82,6 @@ struct data_source_t
 	[self setupTrackingRects];
 }
 
-- (void)removeFromSuperview
-{
-	D(DBF_GutterView, bug("\n"););
-	self.partnerView = nil;
-}
-
 - (void)viewDidMoveToWindow
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidResignKeyNotification object:nil];

--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -330,7 +330,6 @@ private:
 
 - (void)dealloc
 {
-	gutterView.partnerView = nil;
 	gutterView.delegate    = nil;
 	_statusBar.delegate    = nil;
 


### PR DESCRIPTION
On 10.12 beta 3, when closing a window, the following exception is thrown:

Exception Name: NSInternalInconsistencyException
Description: <GutterView 0x7fa71c511150> has reached dealloc but still has a super view. Super views strongly reference there children, so this is being over-released, or has been over-released in the past.

Despite the mention of our GutterView instance being over-released, the actual problem is that we do not call super in our override of `removeFromSuperView`, where we nil out our partner view. A simple fix to avoid crashing would be just calling super in that method so that the view is marked as being removed; however, we can simplify the code and eliminate the need to override our super's method by using a weak reference instead and let ARC automatically handle the zeroing of our partner view.

---

Maybe keeping the strong reference is better, Idk.