### PR TITLE
Add attr.project.swift scope

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -2070,7 +2070,7 @@ namespace
 - (void)setCommandRunner:(command::runner_ptr const&)aRunner
 {
 	_runner = aRunner;
-	if(self.htmlOutputInWindow || self.htmlOutputView.runningCommand)
+	if(self.htmlOutputInWindow || self.htmlOutputView.isRunningCommand)
 	{
 		HTMLOutputWindowController* target = nil;
 

--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -1390,6 +1390,7 @@ namespace
 		{ "attr.project.scons",   "SConstruct",     "build"   },
 		{ "attr.project.lein",    "project.clj",    "build"   },
 		{ "attr.project.cargo",   "Cargo.toml",     "build"   },
+		{ "attr.project.swift",   "Package.swift",  "build"   },
 		{ "attr.project.vagrant", "Vagrantfile",    "vagrant" },
 		{ "attr.project.jekyll",  "_config.yml",    "jekyll"  },
 		{ "attr.test.rspec",      ".rspec",         "test"    },

--- a/Frameworks/DocumentWindow/src/DocumentController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentController.mm
@@ -19,7 +19,6 @@
 #import <HTMLOutputWindow/HTMLOutputWindow.h>
 #import <OakFilterList/FileChooser.h>
 #import <OakSystem/application.h>
-#import <OakSystem/process.h>
 #import <Find/Find.h>
 #import <BundlesManager/BundlesManager.h>
 #import <network/network.h>
@@ -652,7 +651,7 @@ namespace
 		OakShowAlertForWindow(alert, self.window, ^(NSInteger returnCode){
 			if(returnCode == NSAlertDefaultReturn) /* "Stop" */
 			{
-				oak::kill_process_group_in_background(_runner->process_id());
+				[_htmlOutputView stopLoading];
 				_runner.reset();
 				[sender performSelector:@selector(performClose:) withObject:self afterDelay:0];
 			}
@@ -1290,7 +1289,7 @@ namespace
 			auto sheetResponseHandler = ^(NSInteger returnCode){
 				if(returnCode == NSAlertDefaultReturn) /* "Stop" */
 				{
-					oak::kill_process_group_in_background(candidate.commandRunner->process_id());
+					[candidate.htmlOutputView stopLoading];
 					dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 						candidate.commandRunner->wait_for_command(); // Must not be called in main queue
 						dispatch_async(dispatch_get_main_queue(), ^{

--- a/Frameworks/Find/src/FFResultNode.mm
+++ b/Frameworks/Find/src/FFResultNode.mm
@@ -250,9 +250,12 @@ static NSAttributedString* AttributedStringForMatch (std::string const& text, si
 		return _excerpt;
 
 	find::match_t const& m = _match;
-
 	size_t from = m.first - m.excerpt_offset;
 	size_t to   = m.last  - m.excerpt_offset;
+
+	ASSERT_LE(m.first, m.last);
+	ASSERT_LE(from, m.excerpt.size());
+	ASSERT_LE(to, m.excerpt.size());
 
 	std::string prefix = m.excerpt.substr(0, from);
 	std::string middle = m.excerpt.substr(from, to - from);

--- a/Frameworks/Find/src/scan_path.cc
+++ b/Frameworks/Find/src/scan_path.cc
@@ -183,44 +183,44 @@ namespace find
 
 		std::vector<match_t> results;
 
-		std::string const newlines = text::estimate_line_endings(std::begin(text), std::end(text));
+		std::string const crlf = text::estimate_line_endings(std::begin(text), std::end(text));
 
-		size_t bol = 0, lfCount = 0;
-		size_t nextLine = text.find(newlines, bol);
+		size_t bol = 0, crlfCount = 0;
+		size_t eol = text.find(crlf, bol);
 
 		for(auto const& it : ranges)
 		{
-			while(nextLine != std::string::npos && nextLine + newlines.size() <= it.from)
+			while(eol != std::string::npos && eol + crlf.size() <= it.from)
 			{
-				bol = nextLine + newlines.size();
-				nextLine = text.find(newlines, bol);
-				++lfCount;
+				bol = eol + crlf.size();
+				eol = text.find(crlf, bol);
+				++crlfCount;
 			}
 
-			text::pos_t from(lfCount, it.from - bol);
-			size_t fromLine = bol;
+			text::pos_t from(crlfCount, it.from - bol);
+			size_t fromOffset = bol;
 
-			while(nextLine != std::string::npos && nextLine + newlines.size() <= it.to)
+			while(eol != std::string::npos && eol + crlf.size() <= it.to)
 			{
-				bol = nextLine + newlines.size();
-				nextLine = text.find(newlines, bol);
-				++lfCount;
+				bol = eol + crlf.size();
+				eol = text.find(crlf, bol);
+				++crlfCount;
 			}
 
-			text::pos_t to(lfCount, it.to - bol);
-			size_t eol = bol == it.to ? bol : (nextLine != std::string::npos ? nextLine : text.size());
+			text::pos_t to(crlfCount, it.to - bol);
+			size_t toOffset = bol == it.to ? bol : (eol != std::string::npos ? eol : text.size());
 
-			if(it.from - fromLine > 200)
-				fromLine = utf8::find_safe_end(text.begin(), text.begin() + it.from - ((it.from - fromLine) % 150)) - text.begin();
+			if(it.from - fromOffset > 200)
+				fromOffset = utf8::find_safe_end(text.begin(), text.begin() + it.from - ((it.from - fromOffset) % 150)) - text.begin();
 
-			if(eol - fromLine > 500)
-				eol = utf8::find_safe_end(text.begin(), text.begin() + std::max<size_t>(fromLine + 500, it.to)) - text.begin();
+			if(toOffset - fromOffset > 500)
+				toOffset = utf8::find_safe_end(text.begin(), text.begin() + std::max<size_t>(fromOffset + 500, it.to)) - text.begin();
 
 			match_t res(document, crc32.checksum(), it.from, it.to, text::range_t(from, to), it.captures);
-			res.excerpt        = text.substr(fromLine, eol - fromLine);
-			res.excerpt_offset = fromLine;
+			res.excerpt        = text.substr(fromOffset, toOffset - fromOffset);
+			res.excerpt_offset = fromOffset;
 			res.line_number    = from.line;
-			res.newlines       = newlines;
+			res.newlines       = crlf;
 			results.push_back(res);
 		}
 

--- a/Frameworks/Find/src/scan_path.cc
+++ b/Frameworks/Find/src/scan_path.cc
@@ -216,6 +216,9 @@ namespace find
 			if(toOffset - fromOffset > 500)
 				toOffset = utf8::find_safe_end(text.begin(), text.begin() + std::max<size_t>(fromOffset + 500, it.to)) - text.begin();
 
+			ASSERT_LE(fromOffset, it.from);
+			ASSERT_LE(it.to, toOffset);
+
 			match_t res(document, crc32.checksum(), it.from, it.to, text::range_t(from, to), it.captures);
 			res.excerpt        = text.substr(fromOffset, toOffset - fromOffset);
 			res.excerpt_offset = fromOffset;

--- a/Frameworks/Find/src/scan_path.cc
+++ b/Frameworks/Find/src/scan_path.cc
@@ -208,7 +208,7 @@ namespace find
 			}
 
 			text::pos_t to(crlfCount, it.to - bol);
-			size_t toOffset = bol == it.to ? bol : (eol != std::string::npos ? eol : text.size());
+			size_t toOffset = bol == it.to ? bol : (eol != std::string::npos ? (it.to <= eol ? eol : eol + crlf.size()) : text.size());
 
 			if(it.from - fromOffset > 200)
 				fromOffset = utf8::find_safe_end(text.begin(), text.begin() + it.from - ((it.from - fromOffset) % 150)) - text.begin();

--- a/Frameworks/Find/tests/t_scan_path.cc
+++ b/Frameworks/Find/tests/t_scan_path.cc
@@ -217,3 +217,77 @@ void test_file_crlf ()
 	OAK_ASSERT_EQ(matches[2].range.min().line, 2);
 	OAK_ASSERT_EQ(matches[3].range.min().line, 3);
 }
+
+void test_excerpt_lf ()
+{
+	test::jail_t jail;
+	jail.set_content("match", "line 1\nline 2\nline 3\nline 4\n");
+
+	scan_path_t scanner;
+	scanner.set_path(jail.path());
+	std::vector<match_t> matches;
+
+	scanner.set_search_string("line 1");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1");
+
+	scanner.set_search_string("line 1\n");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\n");
+
+	scanner.set_search_string("line 1\nline");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\nline 2");
+
+	scanner.set_search_string("line 1\nline 2\n");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\nline 2\n");
+}
+
+void test_excerpt_crlf ()
+{
+	test::jail_t jail;
+	jail.set_content("match", "line 1\r\nline 2\r\nline 3\r\nline 4\r\n");
+
+	scan_path_t scanner;
+	scanner.set_path(jail.path());
+	std::vector<match_t> matches;
+
+	scanner.set_search_string("line 1");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1");
+
+	scanner.set_search_string("line 1\r");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\r\n");
+
+	scanner.set_search_string("line 1\r\n");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\r\n");
+
+	scanner.set_search_string("line 1\r\nline");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\r\nline 2");
+
+	scanner.set_search_string("line 1\r\nline 2\r");
+	run_scanner(scanner);
+	matches = scanner.accept_matches();
+	OAK_ASSERT_EQ(matches.size(), 1);
+	OAK_ASSERT_EQ(matches[0].excerpt, "line 1\r\nline 2\r\n");
+}

--- a/Frameworks/HTMLOutput/src/HTMLOutput.h
+++ b/Frameworks/HTMLOutput/src/HTMLOutput.h
@@ -7,7 +7,7 @@ extern NSString* const kCommandRunnerURLScheme;
 - (void)stopLoading;
 - (void)loadHTMLString:(NSString*)someHTML;
 
-@property (nonatomic, readonly) BOOL runningCommand;
+@property (nonatomic, getter = isRunningCommand, readonly) BOOL runningCommand;
 
 // Read-only access to the webview is given to allow reading page title, etc.
 @property (nonatomic, readonly) WebView* webView;

--- a/Frameworks/HTMLOutput/src/OakHTMLOutputView.h
+++ b/Frameworks/HTMLOutput/src/OakHTMLOutputView.h
@@ -7,8 +7,4 @@ PUBLIC @interface OakHTMLOutputView : HOBrowserView
 - (void)loadHTMLString:(NSString*)someHTML;
 
 @property (nonatomic, readonly) BOOL runningCommand;
-
-// Read-only access to the webview is given to allow reading page title, etc.
-@property (nonatomic, readonly) WebView* webView;
-@property (nonatomic, readonly) BOOL needsNewWebView;
 @end

--- a/Frameworks/HTMLOutput/src/OakHTMLOutputView.h
+++ b/Frameworks/HTMLOutput/src/OakHTMLOutputView.h
@@ -6,5 +6,5 @@ PUBLIC @interface OakHTMLOutputView : HOBrowserView
 - (void)stopLoading;
 - (void)loadHTMLString:(NSString*)someHTML;
 
-@property (nonatomic, readonly) BOOL runningCommand;
+@property (nonatomic, getter = isRunningCommand, readonly) BOOL runningCommand;
 @end

--- a/Frameworks/HTMLOutput/src/OakHTMLOutputView.mm
+++ b/Frameworks/HTMLOutput/src/OakHTMLOutputView.mm
@@ -11,7 +11,7 @@ extern NSString* const kCommandRunnerURLScheme; // from HTMLOutput.h
 {
 	OBJC_WATCH_LEAKS(OakHTMLOutputView);
 }
-@property (nonatomic) BOOL runningCommand;
+@property (nonatomic, getter = isRunningCommand, readwrite) BOOL runningCommand;
 @property (nonatomic) HOAutoScroll* autoScrollHelper;
 @property (nonatomic) std::map<std::string, std::string> environment;
 @property (nonatomic) NSRect pendingVisibleRect;

--- a/Frameworks/HTMLOutput/src/OakHTMLOutputView.mm
+++ b/Frameworks/HTMLOutput/src/OakHTMLOutputView.mm
@@ -18,9 +18,6 @@ extern NSString* const kCommandRunnerURLScheme; // from HTMLOutput.h
 @end
 
 @implementation OakHTMLOutputView
-
-@dynamic webView, needsNewWebView;
-
 - (void)loadRequest:(NSURLRequest*)aRequest environment:(std::map<std::string, std::string> const&)anEnvironment autoScrolls:(BOOL)flag
 {
 	if(flag)

--- a/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
+++ b/Frameworks/HTMLOutput/src/browser/HOBrowserView.mm
@@ -26,14 +26,6 @@ static void ShowLoadErrorForURL (WebFrame* frame, NSURL* url, NSError* error)
 @end
 
 @implementation HOBrowserView
-
-@dynamic needsNewWebView;
-
-+ (BOOL)requiresConstraintBasedLayout
-{
-	return YES;
-}
-
 - (NSSize)intrinsicContentSize
 {
 	return NSMakeSize(NSViewNoInstrinsicMetric, NSViewNoInstrinsicMetric);

--- a/Frameworks/HTMLOutputWindow/src/HTMLOutputWindow.mm
+++ b/Frameworks/HTMLOutputWindow/src/HTMLOutputWindow.mm
@@ -1,7 +1,6 @@
 #import "HTMLOutputWindow.h"
 #import <OakAppKit/OakAppKit.h>
 #import <OakFoundation/NSString Additions.h>
-#import <OakSystem/process.h>
 #import <command/runner.h>
 #import <oak/debug.h>
 
@@ -108,7 +107,7 @@ OAK_DEBUG_VAR(HTMLOutputWindow);
 		if(returnCode == NSAlertDefaultReturn) /* "Stop" */
 		{
 			[self.window orderOut:self];
-			oak::kill_process_group_in_background(_commandRunner->process_id());
+			[self.htmlOutputView stopLoading];
 			[self.window close];
 		}
 	});

--- a/Frameworks/HTMLOutputWindow/src/HTMLOutputWindow.mm
+++ b/Frameworks/HTMLOutputWindow/src/HTMLOutputWindow.mm
@@ -87,7 +87,7 @@ OAK_DEBUG_VAR(HTMLOutputWindow);
 
 - (BOOL)running
 {
-	return self.htmlOutputView.runningCommand;
+	return self.htmlOutputView.isRunningCommand;
 }
 
 - (BOOL)needsNewWebView

--- a/Frameworks/HTMLOutputWindow/target
+++ b/Frameworks/HTMLOutputWindow/target
@@ -1,4 +1,4 @@
 SOURCES      = src/*.mm
 EXPORT       = src/HTMLOutputWindow.h
-LINK        += HTMLOutput OakAppKit OakFoundation OakSystem command
+LINK        += HTMLOutput OakAppKit OakFoundation command
 FRAMEWORKS   = Cocoa

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -864,7 +864,7 @@ static std::string shell_quote (std::vector<std::string> paths)
 		CGFloat fontSize = settings.get(kSettingsFontSizeKey, 11.0);
 		if(fontName)
 			_font = [NSFont fontWithName:fontName size:fontSize];
-		if(!_font || ![_font.fontName isEqualToString:fontName])
+		if(!_font)
 			_font = [NSFont userFixedPitchFontOfSize:fontSize];
 
 		_showInvisibles = settings.get(kSettingsShowInvisiblesKey, false);

--- a/Frameworks/selection/src/selection.cc
+++ b/Frameworks/selection/src/selection.cc
@@ -797,8 +797,8 @@ namespace ng
 
 	ranges_t move (buffer_api_t const& buffer, ranges_t const& selection, move_unit_type const orgUnit, layout_movement_t const* layout)
 	{
-		static std::set<move_unit_type> const leftward  = { kSelectionMoveLeft,  kSelectionMoveFreehandedLeft, kSelectionMoveToBeginOfLine, kSelectionMoveToBeginOfParagraph, kSelectionMoveToBeginOfTypingPair, kSelectionMoveToBeginOfSoftLine, kSelectionMoveToBeginOfSubWord, kSelectionMoveToBeginOfWord };
-		static std::set<move_unit_type> const rightward = { kSelectionMoveRight, kSelectionMoveFreehandedRight, kSelectionMoveToEndOfLine, kSelectionMoveToEndOfParagraph, kSelectionMoveToEndOfTypingPair, kSelectionMoveToEndOfSoftLine, kSelectionMoveToEndOfSubWord, kSelectionMoveToEndOfWord            };
+		static std::set<move_unit_type> const leftward  = { kSelectionMoveLeft,  kSelectionMoveFreehandedLeft, kSelectionMoveToBeginOfIndentedLine, kSelectionMoveToBeginOfLine, kSelectionMoveToBeginOfParagraph, kSelectionMoveToBeginOfTypingPair, kSelectionMoveToBeginOfSoftLine, kSelectionMoveToBeginOfSubWord, kSelectionMoveToBeginOfWord };
+		static std::set<move_unit_type> const rightward = { kSelectionMoveRight, kSelectionMoveFreehandedRight, kSelectionMoveToEndOfIndentedLine, kSelectionMoveToEndOfLine, kSelectionMoveToEndOfParagraph, kSelectionMoveToEndOfTypingPair, kSelectionMoveToEndOfSoftLine, kSelectionMoveToEndOfSubWord, kSelectionMoveToEndOfWord              };
 
 		bool isLeftward  = leftward.find(orgUnit)  != leftward.end();
 		bool isRightward = rightward.find(orgUnit) != rightward.end();


### PR DESCRIPTION
This scope can be used to support the Swift Package Manager tools (e.g., `swift build`).

-

I am not sure if the build command should be added to the official Swift tmbundle since it is technically part of the Swift Package Manager (Swift 3), which contains a few other tools, so I created a separate tmbundle [swift-package-manager.tmbundle](https://github.com/rdwampler/swift-package-manager.tmbundle). Currently, it only supports building a Swift package, though I plan to add more commands to support `swift package` and `swift test`.

Let me know if you prefer otherwise and I will submit a PR to the official Swift tmbundle.