### PR TITLE
Visual improvement to OakChoiceMenu when using large fonts

### DIFF
--- a/Frameworks/OakTextView/src/OakChoiceMenu.h
+++ b/Frameworks/OakTextView/src/OakChoiceMenu.h
@@ -8,6 +8,7 @@ extern NSUInteger const OakChoiceMenuKeyMovement;
 @property (nonatomic) NSArray* choices;
 @property (nonatomic) NSUInteger choiceIndex;
 @property (nonatomic, readonly) NSString* selectedChoice;
+@property (nonatomic) NSFont* font;
 - (void)showAtTopLeftPoint:(NSPoint)aPoint forView:(NSView*)aView;
 - (BOOL)isVisible;
 - (NSUInteger)didHandleKeyEvent:(NSEvent*)anEvent;

--- a/Frameworks/OakTextView/src/OakChoiceMenu.mm
+++ b/Frameworks/OakTextView/src/OakChoiceMenu.mm
@@ -42,7 +42,7 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	CGFloat const kTableViewPadding = 4;
 	CGFloat const kScrollBarWidth   = 15;
 
-	NSTextField* textField = OakCreateLabel(@"", self.font);
+	NSTextField* textField = OakCreateLabel(@"", self.font, NSLeftTextAlignment, NSLineBreakByTruncatingTail);
 	CGFloat width = 60;
 	for(NSInteger i = 0; i < MIN(_choices.count, 256); ++i)
 	{
@@ -126,7 +126,7 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	NSTextField* res = [aTableView makeViewWithIdentifier:identifier owner:self];
 	if(!res)
 	{
-		res = OakCreateLabel(@"", self.font);
+		res = OakCreateLabel(@"", self.font, NSLeftTextAlignment, NSLineBreakByTruncatingTail);
 		[res sizeToFit];
 		aTableView.rowHeight = NSHeight(res.frame);
 		res.identifier = identifier;

--- a/Frameworks/OakTextView/src/OakChoiceMenu.mm
+++ b/Frameworks/OakTextView/src/OakChoiceMenu.mm
@@ -26,6 +26,7 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	{
 		_choices = [NSArray array];
 		_choiceIndex = NSNotFound;
+		_font = [NSFont controlContentFontOfSize:0];
 	}
 	return self;
 }
@@ -41,7 +42,7 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	CGFloat const kTableViewPadding = 4;
 	CGFloat const kScrollBarWidth   = 15;
 
-	NSTextField* textField = OakCreateLabel(@"", [NSFont controlContentFontOfSize:0]);
+	NSTextField* textField = OakCreateLabel(@"", self.font);
 	CGFloat width = 60;
 	for(NSInteger i = 0; i < MIN(_choices.count, 256); ++i)
 	{
@@ -125,7 +126,9 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	NSTextField* res = [aTableView makeViewWithIdentifier:identifier owner:self];
 	if(!res)
 	{
-		res = OakCreateLabel(@"", [NSFont controlContentFontOfSize:0]);
+		res = OakCreateLabel(@"", self.font);
+		[res sizeToFit];
+		aTableView.rowHeight = NSHeight(res.frame);
 		res.identifier = identifier;
 	}
 	return res;

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -1047,6 +1047,7 @@ doScroll:
 	if(!choiceVector.empty())
 	{
 		_choiceMenu = [OakChoiceMenu new];
+		_choiceMenu.font = [NSFont fontWithName:self.font.fontName size:self.font.pointSize * documentView->font_scale_factor() / 100];
 		_choiceMenu.choices = (__bridge NSArray*)((CFArrayRef)cf::wrap(choiceVector));
 
 		std::string const& currentChoice = documentView->placeholder_content();


### PR DESCRIPTION
On a related note, I would like to apply these changes to the `DIALOG` popup (along with some other enhancements), but since there is already some duplication of code between TextMate and Dialog, I would like to move the Dialog plugin into the main source tree in order to reduce the duplication and easily share more of the code between the two. Thoughts?