### PR TITLE
Don't store our font scale factor as a percentage

### DIFF
--- a/Frameworks/OakTextView/src/OakDocumentView.mm
+++ b/Frameworks/OakTextView/src/OakDocumentView.mm
@@ -256,28 +256,28 @@ private:
 	NSString* lineNumberFontName = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsLineNumberFontNameKey] ?: [_textView.font fontName];
 
 	gutterImages = nil; // force image sizes to be recalculated
-	gutterView.lineNumberFont = [NSFont fontWithName:lineNumberFontName size:round(scaleFactor * [_textView.font pointSize] * _textView.fontScaleFactor / 100)];
+	gutterView.lineNumberFont = [NSFont fontWithName:lineNumberFontName size:round(scaleFactor * [_textView.font pointSize] * _textView.fontScaleFactor)];
 	[gutterView reloadData:self];
 }
 
 - (IBAction)makeTextLarger:(id)sender
 {
-	_textView.fontScaleFactor += 10;
+	_textView.fontScaleFactor += 0.1;
 	[self updateGutterViewFont:self];
 }
 
 - (IBAction)makeTextSmaller:(id)sender
 {
-	if(_textView.fontScaleFactor > 10)
+	if(_textView.fontScaleFactor > 0.1)
 	{
-		_textView.fontScaleFactor -= 10;
+		_textView.fontScaleFactor -= 0.1;
 		[self updateGutterViewFont:self];
 	}
 }
 
 - (IBAction)makeTextStandardSize:(id)sender
 {
-	_textView.fontScaleFactor = 100;
+	_textView.fontScaleFactor = 1;
 	[self updateGutterViewFont:self];
 }
 

--- a/Frameworks/OakTextView/src/OakTextView.h
+++ b/Frameworks/OakTextView/src/OakTextView.h
@@ -35,7 +35,7 @@ PUBLIC @interface OakTextView : OakView
 @property (nonatomic) theme_ptr                             theme;
 @property (nonatomic) NSCursor*                             ibeamCursor;
 @property (nonatomic) NSFont*                               font;
-@property (nonatomic) NSInteger                             fontScaleFactor;
+@property (nonatomic) CGFloat                               fontScaleFactor;
 @property (nonatomic) BOOL                                  antiAlias;
 @property (nonatomic) OTVFontSmoothing                      fontSmoothing;
 @property (nonatomic) size_t                                tabSize;

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSUInteger, OakFlagsState) {
 
 struct document_view_t : ng::buffer_api_t
 {
-	document_view_t (OakDocument* document, std::string const& scopeAttributes, bool scrollPastEnd, NSInteger fontScaleFactor = 100) : _document(document)
+	document_view_t (OakDocument* document, std::string const& scopeAttributes, bool scrollPastEnd, NSInteger fontScaleFactor = 1) : _document(document)
 	{
 		_document_editor = [OakDocumentEditor documentEditorWithDocument:document fontScaleFactor:fontScaleFactor];
 
@@ -261,8 +261,8 @@ struct document_view_t : ng::buffer_api_t
 	NSFont* font () const                         { return _document_editor.font; }
 	void set_font (NSFont* newFont)               { _document_editor.font = newFont; }
 
-	NSInteger font_scale_factor () const          { return _document_editor.fontScaleFactor; }
-	void set_font_scale_factor (NSInteger scale)  { _document_editor.fontScaleFactor = scale; }
+	CGFloat font_scale_factor () const            { return _document_editor.fontScaleFactor; }
+	void set_font_scale_factor (CGFloat scale)    { _document_editor.fontScaleFactor = scale; }
 
 	void set_command_runner (std::function<void(bundle_command_t const&, ng::buffer_api_t const&, ng::ranges_t const&, std::map<std::string, std::string> const&)> const& runner)
 	{
@@ -785,7 +785,7 @@ static std::string shell_quote (std::vector<std::string> paths)
 		return;
 	}
 
-	NSInteger fontScaleFactor = 100;
+	CGFloat fontScaleFactor = 1;
 	if(documentView)
 	{
 		fontScaleFactor = documentView->font_scale_factor();
@@ -1048,7 +1048,7 @@ doScroll:
 	if(!choiceVector.empty())
 	{
 		_choiceMenu = [OakChoiceMenu new];
-		_choiceMenu.font = [NSFont fontWithName:self.font.fontName size:self.font.pointSize * documentView->font_scale_factor() / 100];
+		_choiceMenu.font = [NSFont fontWithName:self.font.fontName size:self.font.pointSize * documentView->font_scale_factor()];
 		_choiceMenu.choices = (__bridge NSArray*)((CFArrayRef)cf::wrap(choiceVector));
 
 		std::string const& currentChoice = documentView->placeholder_content();
@@ -2914,7 +2914,7 @@ static char const* kOakMenuItemTitle = "OakMenuItemTitle";
 
 - (theme_ptr)theme            { return documentView ? documentView->theme() : theme_ptr(); }
 - (NSFont*)font               { return documentView ? documentView->font() : [NSFont userFixedPitchFontOfSize:0]; }
-- (NSInteger)fontScaleFactor  { return documentView ? documentView->font_scale_factor() : 100; }
+- (CGFloat)fontScaleFactor    { return documentView ? documentView->font_scale_factor() : 1; }
 - (size_t)tabSize             { return documentView ? documentView->tab_size() : 2; }
 - (BOOL)softTabs              { return documentView ? documentView->soft_tabs() : NO; }
 - (BOOL)softWrap              { return documentView && documentView->soft_wrap(); }
@@ -2955,7 +2955,7 @@ static char const* kOakMenuItemTitle = "OakMenuItemTitle";
 	}
 }
 
-- (void)setFontScaleFactor:(NSInteger)newFontScaleFactor
+- (void)setFontScaleFactor:(CGFloat)newFontScaleFactor
 {
 	if(documentView)
 	{
@@ -2965,7 +2965,7 @@ static char const* kOakMenuItemTitle = "OakMenuItemTitle";
 		[self scrollIndexToFirstVisible:documentView->begin(documentView->convert(visibleIndex.index).line)];
 	}
 
-	[OTVHUD showHudForView:self withText:[NSString stringWithFormat:@"%ld%%", newFontScaleFactor]];
+	[OTVHUD showHudForView:self withText:[NSString stringWithFormat:@"%.f%%", newFontScaleFactor * 100]];
 }
 
 - (void)setTabSize:(size_t)newTabSize

--- a/Frameworks/document/src/OakDocument.mm
+++ b/Frameworks/document/src/OakDocument.mm
@@ -1515,7 +1515,7 @@ private:
 {
 	if(self.isOpen)
 	{
-		OakDocumentEditor* documentEditor = self.documentEditors.firstObject ?: [OakDocumentEditor documentEditorWithDocument:self fontScaleFactor:100];
+		OakDocumentEditor* documentEditor = self.documentEditors.firstObject ?: [OakDocumentEditor documentEditorWithDocument:self fontScaleFactor:1];
 		[documentEditor performReplacements:someReplacements];
 		return YES;
 	}

--- a/Frameworks/document/src/OakDocumentEditor.h
+++ b/Frameworks/document/src/OakDocumentEditor.h
@@ -9,8 +9,8 @@ namespace ng
 } /* ng */
 
 PUBLIC @interface OakDocumentEditor : NSObject
-+ (instancetype)documentEditorWithDocument:(OakDocument*)aDocument fontScaleFactor:(NSInteger)scale;
-- (instancetype)initWithDocument:(OakDocument*)aDocument fontScaleFactor:(NSInteger)scale;
++ (instancetype)documentEditorWithDocument:(OakDocument*)aDocument fontScaleFactor:(CGFloat)scale;
+- (instancetype)initWithDocument:(OakDocument*)aDocument fontScaleFactor:(CGFloat)scale;
 @property (nonatomic, readonly) OakDocument* document;
 @property (nonatomic) ng::ranges_t selection;
 - (ng::buffer_t&)buffer;
@@ -18,7 +18,7 @@ PUBLIC @interface OakDocumentEditor : NSObject
 - (ng::layout_t&)layout;
 
 @property (nonatomic) NSFont* font;
-@property (nonatomic) NSInteger fontScaleFactor;
+@property (nonatomic) CGFloat fontScaleFactor;
 
 - (void)documentWillSave:(OakDocument*)aDocument;
 - (void)performReplacements:(std::multimap<std::pair<size_t, size_t>, std::string> const&)someReplacements;

--- a/Frameworks/document/src/OakDocumentEditor.mm
+++ b/Frameworks/document/src/OakDocumentEditor.mm
@@ -23,12 +23,12 @@ static int32_t const NSWrapColumnWindowWidth = 0;
 // ====================================
 
 @implementation OakDocumentEditor
-+ (instancetype)documentEditorWithDocument:(OakDocument*)aDocument fontScaleFactor:(NSInteger)scale
++ (instancetype)documentEditorWithDocument:(OakDocument*)aDocument fontScaleFactor:(CGFloat)scale
 {
 	return [[OakDocumentEditor alloc] initWithDocument:aDocument fontScaleFactor:scale];
 }
 
-- (instancetype)initWithDocument:(OakDocument*)aDocument fontScaleFactor:(NSInteger)scale
+- (instancetype)initWithDocument:(OakDocument*)aDocument fontScaleFactor:(CGFloat)scale
 {
 	if(self = [self init])
 	{
@@ -57,7 +57,7 @@ static int32_t const NSWrapColumnWindowWidth = 0;
 		size_t wrapColumn = settings.get(kSettingsWrapColumnKey, NSWrapColumnWindowWidth);
 
 		theme_ptr theme = parse_theme(bundles::lookup(settings.get(kSettingsThemeKey, NULL_STR)));
-		_layout = std::make_unique<ng::layout_t>([_document buffer], theme, to_s(_font.fontName), _font.pointSize * _fontScaleFactor / 100, softWrap, scrollPastEnd, wrapColumn, to_s(_document.folded));
+		_layout = std::make_unique<ng::layout_t>([_document buffer], theme, to_s(_font.fontName), _font.pointSize * _fontScaleFactor, softWrap, scrollPastEnd, wrapColumn, to_s(_document.folded));
 
 		if(settings.get(kSettingsShowWrapColumnKey, false))
 			_layout->set_draw_wrap_column(true);
@@ -88,13 +88,13 @@ static int32_t const NSWrapColumnWindowWidth = 0;
 - (void)setFont:(NSFont*)newFont
 {
 	_font = newFont;
-	_layout->set_font(to_s(_font.fontName), _font.pointSize * _fontScaleFactor / 100);
+	_layout->set_font(to_s(_font.fontName), _font.pointSize * _fontScaleFactor);
 }
 
-- (void)setFontScaleFactor:(NSInteger)scale
+- (void)setFontScaleFactor:(CGFloat)scale
 {
 	_fontScaleFactor = scale;
-	_layout->set_font(to_s(_font.fontName), _font.pointSize * _fontScaleFactor / 100);
+	_layout->set_font(to_s(_font.fontName), _font.pointSize * _fontScaleFactor);
 }
 
 - (ng::ranges_t)selection


### PR DESCRIPTION
While we want to show the font scale factor as a percentage in the UI, internally, we should represent it as a CGFloat, which is more consistent with the NSFont APIs and makes interacting with them easier.

--

Just a nitpick. 😄  