### PR TITLE
Enable bundle editor window’s document icon

### DIFF
--- a/Frameworks/BundleEditor/src/BundleEditor.mm
+++ b/Frameworks/BundleEditor/src/BundleEditor.mm
@@ -743,8 +743,31 @@ static NSMutableDictionary* DictionaryForPropertyList (plist::dictionary_t const
 	return bundleItem;
 }
 
-- (BOOL)window:(NSWindow*)aWindow shouldDragDocumentWithEvent:(NSEvent*)anEvent from:(NSPoint)dragImageLocation withPasteboard:(NSPasteboard*)aPasteboard { return NO; }
-- (BOOL)window:(NSWindow*)aWindow shouldPopUpDocumentPathMenu:(NSMenu*)aMenu                                                                              { return NO; }
+- (BOOL)window:(NSWindow*)aWindow shouldDragDocumentWithEvent:(NSEvent*)anEvent from:(NSPoint)dragImageLocation withPasteboard:(NSPasteboard*)aPasteboard
+{
+	return bundleItem && bundleItem->paths().size() == 1;
+}
+
+
+- (BOOL)window:(NSWindow*)aWindow shouldPopUpDocumentPathMenu:(NSMenu*)menu
+{
+	if(!bundleItem)
+		return NO;
+	
+	const auto& paths = bundleItem->paths();
+	if(paths.size() == 1)
+		return YES;
+	
+	[menu removeAllItems];
+	for(std::string const& path : paths)
+	{
+		NSMenuItem* item = [self createMenuItemForCxxPath:path];
+		item.title = [[NSString stringWithCxxString:path] stringByAbbreviatingWithTildeInPath];
+		[menu addItem:item];
+		item.state = NSOffState;
+	}
+	return YES;
+}
 
 - (void)setBundleItem:(bundles::item_ptr const&)aBundleItem
 {
@@ -765,8 +788,15 @@ static NSMutableDictionary* DictionaryForPropertyList (plist::dictionary_t const
 	item_info_t const& info = info_for(bundleItem->kind());
 
 	[[self window] setTitle:[NSString stringWithCxxString:bundleItem->name_with_bundle()]];
-	[[self window] setRepresentedFilename:NSHomeDirectory()];
-	[[[self window] standardWindowButton:NSWindowDocumentIconButton] setImage:[[NSWorkspace sharedWorkspace] iconForFileType:[NSString stringWithCxxString:info.file_type]]];
+
+	const auto& paths = bundleItem->paths();
+	if(paths.size() == 1)
+		self.window.representedURL = [NSURL fileURLWithPath:[NSString stringWithCxxString:paths.front()]];
+	else
+	{
+		self.window.representedFilename = NSHomeDirectory();
+		[self.window standardWindowButton:NSWindowDocumentIconButton].image = [[NSWorkspace sharedWorkspace] iconForFileType:[NSString stringWithCxxString:info.file_type]];
+	}
 
 	plist::dictionary_t const& plist = it != changes.end() ? it->second : bundleItem->plist();
 	if(info.plist_key == NULL_STR)


### PR DESCRIPTION
When there is only one path for an item, that path is used as the representedURL. When there are multiple paths, we still allow showing the menu, but it has one item per path instead of showing the directory tree.