### PR TITLE
Don't set our document with a default constructed document_ptr

### DIFF
--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -528,7 +528,6 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 			[self saveCommitMessage:commitMessage];
 	}
 
-	[self.documentView setDocument:document::document_ptr()];
 	[self sendCommitMessageToClient:NO];
 	[self.window orderOut:self];
 }


### PR DESCRIPTION
This was never necessary since our documentView will set this to
document_ptr() when it's released, though it was harmless. But now,
document_ptr is just a thin wrapper around OakDocument and the default
constructor does nothing. As a result we were basically setting the
text view OakDocument instance to nil.

After commit f9e02d9, when the commit window closes, this would
noticeably cause the text view to turn "white" when using a dark theme.