### PR TITLE
Add “git config commit.gpgsign false” to SCM tests

### DIFF
--- a/Frameworks/CrashReporter/src/CrashReporter.mm
+++ b/Frameworks/CrashReporter/src/CrashReporter.mm
@@ -151,20 +151,17 @@ static std::string create_gzipped_file (std::string const& path)
 				{
 					didSend.insert(report);
 
-					if(NSClassFromString(@"NSUserNotification"))
+					auto location = response.find("location");
+					if(location != response.end())
 					{
-						auto location = response.find("location");
-						if(location != response.end())
-						{
-							NSString* path = [NSString stringWithCxxString:report];
-							NSString* url  = [NSString stringWithCxxString:location->second];
+						NSString* path = [NSString stringWithCxxString:report];
+						NSString* url  = [NSString stringWithCxxString:location->second];
 
-							NSUserNotification* notification = [NSUserNotification new];
-							notification.title           = @"Crash Report Sent";
-							notification.informativeText = @"Diagnostic information has been sent to MacroMates.com regarding your last crash.";
-							notification.userInfo        = @{ @"path" : path, @"url" : url };
-							[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
-						}
+						NSUserNotification* notification = [NSUserNotification new];
+						notification.title           = @"Crash Report Sent";
+						notification.informativeText = @"Diagnostic information has been sent to MacroMates.com regarding your last crash.";
+						notification.userInfo        = @{ @"path" : path, @"url" : url };
+						[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
 					}
 				}
 

--- a/Frameworks/scm/tests/t_git.cc
+++ b/Frameworks/scm/tests/t_git.cc
@@ -10,7 +10,7 @@ struct setup_t
 	setup_t (std::string const& cmd)
 	{
 		static std::string const git = scm::find_executable("git", "TM_GIT");
-		std::string const script = text::format("{ cd '%1$s' && '%2$s' init && '%2$s' config user.email 'test@example.com' && '%2$s' config user.name 'Test Test' && touch .dummy && '%2$s' add .dummy && '%2$s' commit .dummy -mGetHead && %3$s ; } >/dev/null", jail.path().c_str(), git.c_str(), cmd.c_str());
+		std::string const script = text::format("{ cd '%1$s' && '%2$s' init && '%2$s' config user.email 'test@example.com' && '%2$s' config user.name 'Test Test' && '%2$s' config commit.gpgsign false && touch .dummy && '%2$s' add .dummy && '%2$s' commit .dummy -mGetHead && %3$s ; } >/dev/null", jail.path().c_str(), git.c_str(), cmd.c_str());
 		if(io::exec("/bin/sh", "-c", script.c_str(), nullptr) != NULL_STR)
 		{
 			if(info = scm::info(jail.path()))


### PR DESCRIPTION
This allows tests to pass even when a global .gitconfig has `gpgsign=true`.