### PR TITLE
Use yellow background and underline for project find results

### DIFF
--- a/Frameworks/CrashReporter/src/CrashReporter.mm
+++ b/Frameworks/CrashReporter/src/CrashReporter.mm
@@ -151,20 +151,17 @@ static std::string create_gzipped_file (std::string const& path)
 				{
 					didSend.insert(report);
 
-					if(NSClassFromString(@"NSUserNotification"))
+					auto location = response.find("location");
+					if(location != response.end())
 					{
-						auto location = response.find("location");
-						if(location != response.end())
-						{
-							NSString* path = [NSString stringWithCxxString:report];
-							NSString* url  = [NSString stringWithCxxString:location->second];
+						NSString* path = [NSString stringWithCxxString:report];
+						NSString* url  = [NSString stringWithCxxString:location->second];
 
-							NSUserNotification* notification = [NSUserNotification new];
-							notification.title           = @"Crash Report Sent";
-							notification.informativeText = @"Diagnostic information has been sent to MacroMates.com regarding your last crash.";
-							notification.userInfo        = @{ @"path" : path, @"url" : url };
-							[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
-						}
+						NSUserNotification* notification = [NSUserNotification new];
+						notification.title           = @"Crash Report Sent";
+						notification.informativeText = @"Diagnostic information has been sent to MacroMates.com regarding your last crash.";
+						notification.userInfo        = @{ @"path" : path, @"url" : url };
+						[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
 					}
 				}
 

--- a/Frameworks/Find/src/FFResultNode.mm
+++ b/Frameworks/Find/src/FFResultNode.mm
@@ -109,7 +109,9 @@ static NSAttributedString* AttributedStringForMatch (std::string const& text, si
 	NSFontTraitMask matchFontTraits = NSBoldFontMask;
 	NSDictionary* matchAttributes = @{
 		NSForegroundColorAttributeName : [NSColor blackColor],
-		NSBackgroundColorAttributeName : [NSColor colorWithCalibratedWhite:0.9 alpha:1]
+		NSBackgroundColorAttributeName : [NSColor colorWithCalibratedRed:0.92 green:0.86 blue:0.48 alpha:0.5],
+		NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle),
+		NSUnderlineColorAttributeName : [NSColor colorWithCalibratedRed:0.89 green:0.72 blue:0.0 alpha:1.0],
 	};
 
 	string_builder_t builder(NSLineBreakByTruncatingTail);

--- a/Frameworks/Find/src/FFResultsViewController.mm
+++ b/Frameworks/Find/src/FFResultsViewController.mm
@@ -51,8 +51,13 @@ static FFResultNode* PreviousNode (FFResultNode* node)
 	if(self.backgroundStyle == NSBackgroundStyleDark)
 	{
 		NSMutableAttributedString* str = [res mutableCopy];
+		[str enumerateAttributesInRange:NSMakeRange(0, str.length) options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock:^(NSDictionary* attrs, NSRange range, BOOL *stop){
+			if(attrs[NSBackgroundColorAttributeName] != nil)
+				[str addAttribute:NSBackgroundColorAttributeName value:[NSColor colorWithCalibratedWhite:1.0 alpha:0.30] range:range];
+			if(attrs[NSUnderlineColorAttributeName] != nil)
+				[str addAttribute:NSUnderlineColorAttributeName value:[NSColor whiteColor] range:range];
+		}];
 		[str addAttribute:NSForegroundColorAttributeName value:[NSColor alternateSelectedControlTextColor] range:NSMakeRange(0, [str length])];
-		[str removeAttribute:NSBackgroundColorAttributeName range:NSMakeRange(0, [str length])];
 		res = str;
 	}
 	return res;


### PR DESCRIPTION
This style is a de facto standard across a handful of popular Mac apps.

<img width="321" alt="screen shot 2016-09-10 at 12 50 09 am" src="https://cloud.githubusercontent.com/assets/14237/18408857/8d97136e-76f0-11e6-82ef-81e1cb7798d6.png">
