### PR TITLE
Fix the Find window status bar font

### DIFF
--- a/Frameworks/Find/src/FindWindowController.mm
+++ b/Frameworks/Find/src/FindWindowController.mm
@@ -26,7 +26,6 @@ NSButton* OakCreateClickableStatusBar ()
 	res.alignment  = NSLeftTextAlignment;
 	res.bordered   = NO;
 	res.buttonType = NSToggleButton;
-	res.font       = OakStatusBarFont();
 	res.title      = @"";
 
 	[res setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow forOrientation:NSLayoutConstraintOrientationHorizontal];
@@ -789,7 +788,12 @@ static NSButton* OakCreateStopSearchButton ()
 
 	NSMutableParagraphStyle* paragraphStyle = [[NSMutableParagraphStyle alloc] init];
 	[paragraphStyle setLineBreakMode:NSLineBreakByTruncatingMiddle];
-	[res addAttributes:@{ NSParagraphStyleAttributeName : paragraphStyle, NSForegroundColorAttributeName : [NSColor textColor] } range:NSMakeRange(0, [[res string] length])];
+	NSDictionary* globalAttrs = @{
+		NSParagraphStyleAttributeName  : paragraphStyle,
+		NSForegroundColorAttributeName : [NSColor textColor],
+		NSFontAttributeName            : OakStatusBarFont(),
+	};
+	[res addAttributes:globalAttrs range:NSMakeRange(0, [[res string] length])];
 
 	return res;
 }


### PR DESCRIPTION
Using an attributed string apparently overrides the field's own font. This makes the string use the proper system font.