### PR TITLE
fixup! Only set table view’s row height during sizeToFit

### DIFF
--- a/Frameworks/OakTextView/src/OakChoiceMenu.mm
+++ b/Frameworks/OakTextView/src/OakChoiceMenu.mm
@@ -43,7 +43,6 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 	CGFloat const kScrollBarWidth   = 15;
 
 	NSTextField* textField = OakCreateLabel(@"", self.font, NSLeftTextAlignment, NSLineBreakByTruncatingTail);
-	tableView.rowHeight = NSHeight(textField.frame);
 
 	CGFloat width = 60;
 	for(NSInteger i = 0; i < MIN(_choices.count, 256); ++i)
@@ -52,6 +51,8 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 		[textField sizeToFit];
 		width = std::max(width, kTableViewPadding + NSWidth(textField.frame));
 	}
+
+	tableView.rowHeight = NSHeight(textField.frame);
 
 	if([_choices count] > 10)
 		width += kScrollBarWidth;


### PR DESCRIPTION
We need to set the row height after calling sizeToFit on textField.

---

I initially had the same code, but at larger font scales the table height would not be correct, so I set it in the delegate method.  I didn't notice any issues so I never revisited it.