### PR TITLE
Make OakPopOutAnimation window a child of the main window

### DIFF
--- a/Frameworks/OakAppKit/src/OakPopOutAnimation.h
+++ b/Frameworks/OakAppKit/src/OakPopOutAnimation.h
@@ -1,3 +1,3 @@
 #include <oak/misc.h>
 
-PUBLIC void OakShowPopOutAnimation (NSRect aRect, NSImage* image, BOOL hidePrevious = YES);
+PUBLIC void OakShowPopOutAnimation (NSView* parentView, NSRect aRect, NSImage* image, BOOL hidePrevious = YES);

--- a/Frameworks/OakAppKit/tests/gui_pop_out.mm
+++ b/Frameworks/OakAppKit/tests/gui_pop_out.mm
@@ -18,7 +18,7 @@
 - (void)mouseDown:(NSEvent*)anEvent
 {
 	NSRect p = [[self window] convertRectToScreen:(NSRect){ [anEvent locationInWindow], NSMakeSize(48, 48) }];
-	OakShowPopOutAnimation(p, [NSImage imageNamed:NSImageNameComputer]);
+	OakShowPopOutAnimation(nil, p, [NSImage imageNamed:NSImageNameComputer]);
 }
 @end
 

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -610,7 +610,7 @@ struct refresh_helper_t
 						NSRect imageRect;
 						NSImage* image = [_self imageForRanges:range imageRect:&imageRect];
 						imageRect = [[_self window] convertRectToScreen:[_self convertRect:imageRect toView:nil]];
-						OakShowPopOutAnimation(imageRect, image);
+						OakShowPopOutAnimation(_self, imageRect, image);
 					}
 				}
 
@@ -790,7 +790,7 @@ static std::string shell_quote (std::vector<std::string> paths)
 		NSRect imageRect;
 		NSImage* image = [self imageForRanges:range imageRect:&imageRect];
 		imageRect = [[self window] convertRectToScreen:[self convertRect:imageRect toView:nil]];
-		OakShowPopOutAnimation(imageRect, image, firstRange);
+		OakShowPopOutAnimation(self, imageRect, image, firstRange);
 		firstRange = NO;
 	}
 }


### PR DESCRIPTION
This makes it so that the animation stays with the window when moving the window or activating Mission Control while it's still visible.