### PR TITLE
Change from deprecated CFPropertyListWriteToStream

### DIFF
--- a/Applications/pretty_plist/src/pretty_plist.cc
+++ b/Applications/pretty_plist/src/pretty_plist.cc
@@ -48,7 +48,7 @@ static void parse_plist (FILE* fp, bool ascii, bool extended)
 				{
 					CFStringRef error = nullptr;
 					CFWriteStreamOpen(writeStream);
-					CFPropertyListWriteToStream(cfPlist, writeStream, kCFPropertyListXMLFormat_v1_0, &error);
+					CFPropertyListWrite(cfPlist, writeStream, kCFPropertyListXMLFormat_v1_0, 0, &error);
 					CFWriteStreamClose(writeStream);
 					CFRelease(writeStream);
 				}

--- a/Frameworks/plist/src/plist.cc
+++ b/Frameworks/plist/src/plist.cc
@@ -212,7 +212,7 @@ namespace plist
 				{
 					if(CFWriteStreamOpen(writeStream))
 					{
-						res = CFPropertyListWriteToStream(cfPlist, writeStream, format == kPlistFormatBinary ? kCFPropertyListBinaryFormat_v1_0 : kCFPropertyListXMLFormat_v1_0, nullptr) != 0;
+						res = CFPropertyListWrite(cfPlist, writeStream, format == kPlistFormatBinary ? kCFPropertyListBinaryFormat_v1_0 : kCFPropertyListXMLFormat_v1_0, 0, nullptr) != 0;
 						CFWriteStreamClose(writeStream);
 					}
 					CFRelease(writeStream);


### PR DESCRIPTION
to modern CFPropertyListWrite.
@sorbits I'm gonna make more changes like this if I can to make build more readable (no warnings about deprecated code). But I'm a beginner in Objective-C.
