### PR TITLE
Specify Line Endings For ABNF Grammars

### DIFF
--- a/Applications/TextMate/resources/Default.tmProperties
+++ b/Applications/TextMate/resources/Default.tmProperties
@@ -28,6 +28,9 @@ softWrap         = true
 spellChecking    = true
 spellingLanguage = 'en'
 
+[ source.abnf ]
+lineEndings      = "\r\n"
+
 [ source.ruby ]
 softTabs         = true
 tabSize          = 2


### PR DESCRIPTION
Hi,

as promised in my [recent mail](http://textmate.1073791.n5.nabble.com/Feature-Request-File-Scope-Specific-Line-Endings-tp30984p30996.html), this pull request explicitly sets the line ending for [ABNF][] files. If I should change anything, then please just comment below.

[ABNF]: https://en.wikipedia.org/wiki/Augmented_Backus–Naur_form

By the way: I wanted to build TextMate, but the build process fails with the following error message on my machine (macOS 10.12.1):

```
[1/1] Generate ‘build.ninja’…
[3/538] Run test ‘/Users/rene/build/TextMate/Frameworks/file/test_file’…
FAILED: /Users/rene/build/TextMate/Frameworks/file/test_file.run
/Users/rene/build/TextMate/Frameworks/file/test_file  && touch /Users/rene/build/TextMate/Frameworks/file/test_file.run
/Users/rene/Documents/Development/Applications/TextMate/Frameworks/file/tests/t_status.cc:30: Skipping file::status tests (no fixtures)
/Users/rene/Documents/Development/Applications/TextMate/Frameworks/file/tests/t_status.cc:40: Skipping file::status read-only tests (no fixtures)
test_file: 1 of 11 tests failed:
/Users/rene/Documents/Development/Applications/TextMate/Frameworks/file/tests/t_type.cc:51: Expected (settings_for_path("/foo/CMakeLists.txt" ).get(kSettingsFileTypeKey, "unset") == "CMakeLists.txt"), found ("source.cmake" != "CMakeLists.txt")
[12/538] Compile ‘Frameworks/OakCommand/src/OakCommand.mm’…
FAILED: /Users/rene/build/TextMate/Frameworks/OakCommand/src/OakCommand.o
xcrun clang++ -include /Users/rene/build/TextMate/Shared/PCH/prelude.mm -c -pipe -fPIC -gdwarf-2 -m64 -mmacosx-version-min=10.8 -funsigned-char -D'NULL_STR="\uFFFF"' -DREST_API='"https://api.textmate.org"' -Wall -Wwrite-strings -Wformat -Winit-self -Wmissing-include-dirs -Wno-parentheses -Wno-sign-compare -Wno-switch -IShared/include -fcolor-diagnostics -DNDEBUG -Os -fvisibility=hidden -std=c++1z -stdlib=libc++ -fobjc-abi-version=3 -fobjc-arc -fobjc-call-cxx-cdtors  -o /Users/rene/build/TextMate/Frameworks/OakCommand/src/OakCommand.o -MMD -MF /Users/rene/build/TextMate/Frameworks/OakCommand/src/OakCommand.o.d -I/Users/rene/build/TextMate/include Frameworks/OakCommand/src/OakCommand.mm
Frameworks/OakCommand/src/OakCommand.mm:19:9: fatal error: 'BundleEditor/BundleEditor.h' file not found
#import <BundleEditor/BundleEditor.h>
        ^
1 error generated.
ninja: build stopped: subcommand failed.
```

Is this expected or am I doing something wrong? Where is the usual place to report this kind of issues?

Kind regards,
  René