### PR TITLE
Change build_dir to current folder

### DIFF
--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@ function error () { printf >&2 "%s\n\nPlease see README.md for build instruction
 # = Fallback build directory and signing identity =
 # =================================================
 
-: ${builddir:=$HOME/build/TextMate}
+: ${builddir:=./build/}
 : ${identity:=-}
 : ${capnp_prefix:=/usr/local}
 : ${rest_api:=https://api.textmate.org}


### PR DESCRIPTION
I think it's better to make build folder as current one (to not mess with ~/ directly).