### PR TITLE
SyntaxMate: XPC Service for third-party apps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "vendor/kvdb/vendor"]
 	path = vendor/kvdb/vendor
 	url = https://github.com/textmate/kvdb.git
+[submodule "Applications/SyntaxMate/resources/SyntaxMate.tmBundle"]
+	path = Applications/SyntaxMate/resources/SyntaxMate.tmBundle
+	url = https://github.com/shpakovski/syntaxmate.tmbundle.git

--- a/Applications/SyntaxMate/resources/Default.tmProperties
+++ b/Applications/SyntaxMate/resources/Default.tmProperties
@@ -1,0 +1,7 @@
+binary   = "{*.{ai,gif,icns,ico,jpg,jpeg,m4v,nib,o,pdf,png,psd,pyc,rtf,scssc,tif,tiff,xib},Icon\r}"
+
+[ attr.untitled ]
+fileType = text.plain
+
+[ "{BUILD,README,INSTALL,LICENSE,COPYING,TODO}" ]
+fileType = "text.plain"

--- a/Applications/SyntaxMate/resources/Info.plist
+++ b/Applications/SyntaxMate/resources/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>${TARGET_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.macromates.${TARGET_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/Applications/SyntaxMate/src/SyntaxMate.h
+++ b/Applications/SyntaxMate/src/SyntaxMate.h
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ * Custom domain for SyntaxMate errors.
+ */
+extern NSString* const SyntaxMateErrorDomain;
+
+/*!
+ * The type of SyntaxMate error.
+ *
+ * @field SyntaxMateErrorInvalidInput RPC call parameters are invalid.
+ * @field SyntaxMateErrorUnknownFileType Path extension cannot be recognized.
+ * @field SyntaxMateErrorUnknownTheme Custom theme is not available in the package.
+ */
+typedef NS_ENUM(NSInteger, SyntaxMateError) {
+	SyntaxMateErrorInvalidInput = -1,
+	SyntaxMateErrorUnknownFileType = -2,
+	SyntaxMateErrorUnknownTheme = -3
+};
+
+/*!
+ * Syntax highlighting interface for clients.
+ */
+@protocol SyntaxMate
+
+/*!
+ * Parses attributed string with source code.
+ *
+ * Unfortunately, you cannot pass `NSAttributedString` through XPC, so you should transfer source code as `NSData`.
+ *
+ * @param sourceCode `NSAttributedString` archived into `NSData` for XPC transfer.
+ * @param path File name for automatic selection of the most suitable grammar.
+ * @param reply The asynchronous callback with syntax highlighted `NSAttributedString` or error in case of failure.
+ */
+- (void)highlightSourceCode:(NSData*)sourceCode withPath:(NSString*)path reply:(void (^)(NSData* _Nullable, NSError* _Nullable))reply NS_SWIFT_NAME(highlight(_:path:reply:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Applications/SyntaxMate/src/SyntaxMateImpl.h
+++ b/Applications/SyntaxMate/src/SyntaxMateImpl.h
@@ -1,0 +1,7 @@
+#import "SyntaxMate.h"
+
+/*
+ * Primitive syntax highlighter.
+ */
+@interface SyntaxMateImpl : NSObject <SyntaxMate>
+@end

--- a/Applications/SyntaxMate/src/SyntaxMateImpl.mm
+++ b/Applications/SyntaxMate/src/SyntaxMateImpl.mm
@@ -1,0 +1,129 @@
+#import "SyntaxMateImpl.h"
+
+#import <buffer/buffer.h>
+#import <bundles/query.h>
+#import <theme/theme.h>
+#import <parse/parse.h>
+#import <parse/grammar.h>
+#import <ns/ns.h>
+#import <file/type.h>
+#import <OakFoundation/NSString Additions.h>
+
+NSString* const SyntaxMateErrorDomain = @"com.macromates.SyntaxMate.Error";
+
+@implementation SyntaxMateImpl
+
+#pragma mark - Public API
+
+- (void)highlightSourceCode:(NSData*)input withPath:(NSString*)path reply:(void (^)(NSData*, NSError*))reply
+{
+	if(reply == nil)
+		return;
+	
+	// Validate input or return with error
+	if(input.length == 0)
+	{
+		NSDictionary* info = @{ NSLocalizedDescriptionKey: @"The first parameter must be non-empty piece of data" };
+		reply(nil, [NSError errorWithDomain:SyntaxMateErrorDomain code:SyntaxMateErrorInvalidInput userInfo:info]);
+		return;
+	}
+	if(path.length == 0)
+	{
+		NSDictionary* info = @{ NSLocalizedDescriptionKey: @"The second parameter must be non-empty file name" };
+		reply(nil, [NSError errorWithDomain:SyntaxMateErrorDomain code:SyntaxMateErrorInvalidInput userInfo:info]);
+		return;
+	}
+	
+	// The input parameter must be `NSAttributedString` archived into `NSData` with secure coding
+	NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:input];
+	unarchiver.requiresSecureCoding = YES;
+	NSMutableAttributedString* sourceCode = [[unarchiver decodeObjectOfClass:NSAttributedString.class forKey:NSKeyedArchiveRootObjectKey] mutableCopy];
+	[unarchiver finishDecoding];
+	if(sourceCode == nil)
+	{
+		NSDictionary* info = @{ NSLocalizedDescriptionKey: @"The first parameter must be of type NSMutableAttributedString archived with flag requiresSecureCoding" };
+		reply(nil, [NSError errorWithDomain:SyntaxMateErrorDomain code:SyntaxMateErrorInvalidInput userInfo:info]);
+		return;
+	}
+	
+	// Highlight source code using TextMate engine
+	NSError* error;
+	if(![SyntaxMateImpl addStylesToSourceCode:sourceCode withPath:path error:&error])
+	{
+		reply(nil, error);
+		return;
+	}
+	
+	//	Archive result and send it back to the client
+	NSMutableData* output = [[NSMutableData alloc] init];
+	NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:output];
+	archiver.requiresSecureCoding = YES;
+	[archiver encodeObject:sourceCode forKey:NSKeyedArchiveRootObjectKey];
+	[archiver finishEncoding];
+	reply(output, nil);
+}
+
+#pragma mark - Private API
+
++ (BOOL)addStylesToSourceCode:(NSMutableAttributedString*)styled withPath:(NSString*)path error:(NSError**)errorPtr
+{
+	NSParameterAssert(errorPtr);
+
+	// Make sure that path extension is registered in the SyntaxMate bundle
+	std::string fileType = file::type_from_path(to_s(path));
+	if(fileType == NULL_STR)
+	{
+		NSDictionary* info = @{ NSLocalizedDescriptionKey: @"The first parameter must be of type NSMutableAttributedString archived with flag requiresSecureCoding" };
+		*errorPtr = [NSError errorWithDomain:SyntaxMateErrorDomain code:SyntaxMateErrorUnknownFileType userInfo:info];
+		return NO;
+	}
+	
+	//	Make sure that custom Theme is available TODO: Provide read-only access to UIDs via SyntaxMate protocol
+	theme_ptr theme = parse_theme(bundles::lookup(std::string("CAB58494-D1A3-4BAD-BBC6-DAED679AD20B")));
+	if(!theme)
+	{
+		NSDictionary* info = @{ NSLocalizedDescriptionKey: @"The first parameter must be of type NSMutableAttributedString archived with flag requiresSecureCoding" };
+		*errorPtr = [NSError errorWithDomain:SyntaxMateErrorDomain code:SyntaxMateErrorUnknownTheme userInfo:info];
+		return NO;
+	}
+
+	// Clear original colors and styles
+	NSString* plain = styled.string;
+	for(NSString* attr in @[NSForegroundColorAttributeName, NSBackgroundColorAttributeName, NSUnderlineStyleAttributeName, NSStrikethroughStyleAttributeName])
+		[styled removeAttribute:attr range:NSMakeRange(0, plain.length)];
+	
+	// Non-empty file type guarantees that grammar is available in the package
+	// Buffer is used because plain std::string is too short for some requests
+	ng::buffer_t buffer;
+	buffer.insert(0, to_s(plain));
+	for(auto item : bundles::query(bundles::kFieldGrammarScope, fileType, scope::wildcard, bundles::kItemTypeGrammar))
+	{
+		buffer.set_grammar(item);
+		break;
+	}
+	
+	// Parse source code by using configured Grammar and Theme
+	buffer.wait_for_repair();
+	std::map<size_t, scope::scope_t> scopes = buffer.scopes(0, buffer.size());
+
+	// Parsing is done, add styles to the original mutable attributed string
+	size_t bufferFrom = 0, stringLocation = 0;
+	for(auto pair = scopes.begin(); pair != scopes.end();)
+	{
+		styles_t styles = theme->styles_for_scope(pair->second);
+		size_t bufferTo = ++pair != scopes.end() ? pair->first : buffer.size();
+		size_t stringLength = [NSString stringWithCxxString:buffer.substr(bufferFrom, bufferTo)].length;
+		NSDictionary* attrs = @{
+			NSForegroundColorAttributeName: [NSColor colorWithCGColor:styles.foreground()],
+			NSBackgroundColorAttributeName: [NSColor colorWithCGColor:styles.background()],
+			NSUnderlineStyleAttributeName: @(styles.underlined() ? NSUnderlineStyleSingle : NSUnderlineStyleNone),
+			NSStrikethroughStyleAttributeName: @(styles.strikethrough() ? NSUnderlineStyleSingle : NSUnderlineStyleNone)
+		};
+		[styled addAttributes:attrs range:NSMakeRange(stringLocation, stringLength)];
+		bufferFrom = bufferTo;
+		stringLocation += stringLength;
+	}
+	return YES;
+}
+
+@end

--- a/Applications/SyntaxMate/src/main.mm
+++ b/Applications/SyntaxMate/src/main.mm
@@ -1,0 +1,57 @@
+#import "SyntaxMateImpl.h"
+
+#import <settings/settings.h>
+#import <buffer/buffer.h>
+
+/// Single instance which creates new SyntaxMateImpl for each request
+@interface ConnectionHandler : NSObject <NSXPCListenerDelegate>
+@end
+
+#pragma mark
+
+int main (int argc, char const* argv[])
+{
+	// Parse only SyntaxMate bundle packaged into this XPC Sevice
+	std::vector<std::string> paths;
+	paths.push_back(std::string(path::join(NSBundle.mainBundle.bundleURL.fileSystemRepresentation, "Contents/Resources")));
+	
+	// Keep parsed bundle in the local Caches folder
+	NSURL* cachesURL = [NSFileManager.defaultManager URLForDirectory:NSCachesDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:NULL];
+	std::string bundlesIndexCachePath([cachesURL URLByAppendingPathComponent:@"TextMateBundlesIndex.binary"].fileSystemRepresentation);
+	
+	// Convert property lists into fast binaries
+	plist::cache_t cache;
+	cache.load(bundlesIndexCachePath);
+	auto index = create_bundle_index(paths, cache);
+	bundles::set_index(index.first, index.second);
+	
+	// Start listening for incoming requests from the parent bundle
+	static ConnectionHandler *delegate = nil;
+	delegate = [[ConnectionHandler alloc] init];
+	NSXPCListener* listener = [NSXPCListener serviceListener];
+	listener.delegate = delegate;
+	
+	// Listen to incoming connections while the service is running
+	[listener resume]; // This method will never return
+	return 0;
+}
+
+#pragma mark
+
+@implementation ConnectionHandler
+
+- (BOOL)listener:(NSXPCListener*)listener shouldAcceptNewConnection:(NSXPCConnection*)newConnection
+{	
+	// Declare support for RPC calls using SyntaxMate protocol
+	newConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SyntaxMate)];
+	
+	// Create new object conforming to the SyntaxMate protocol that will be released once request is completed
+	id<SyntaxMate> exportedObject = [[SyntaxMateImpl alloc] init];
+	newConnection.exportedObject = exportedObject;
+
+	// Report to macOS that incoming connection is accepted
+	[newConnection resume];
+	return YES;
+}
+
+@end

--- a/Applications/SyntaxMate/target
+++ b/Applications/SyntaxMate/target
@@ -1,0 +1,4 @@
+CP_Resources     = resources/*
+SOURCES          = src/*.{mm}
+LINK            += file theme
+BUNDLE_EXTENSION = xpc


### PR DESCRIPTION
Hello!

This XPC Service can be copied into any Mac app and then used like `sourcekit` in Xcode.
I was not sure if it makes sense to bloat this folder with one more app.
So you would find the [Demo](https://github.com/shpakovski/SyntaxMateDemo) project in my personal repo.

Any feedback? 😃