### PR TITLE
Stop exporting scan_path.h

### DIFF
--- a/Frameworks/Find/target
+++ b/Frameworks/Find/target
@@ -1,6 +1,6 @@
 SOURCES      = src/*.{cc,mm}
 TESTS        = tests/*.cc
-EXPORT       = src/Find.h src/scan_path.h
+EXPORT       = src/Find.h
 CP_Resources = resources/*
 LINK        += OakAppKit OakFoundation Preferences document io ns regexp settings text
 FRAMEWORKS   = Cocoa


### PR DESCRIPTION
This header was removed in commit 2ffbfe02a568a41283b2bd4e7a27a69fcbb03aa7.
