### PR TITLE
Added the ability to customize the tab title display via new 'tabTitle' tm_properties variable

### DIFF
--- a/.tm_properties
+++ b/.tm_properties
@@ -2,6 +2,7 @@
 windowTitleProject   = '${projectDirectory:+ — ${projectDirectory/^.*\///}}'
 windowTitleFramework = '${TM_DIRECTORY/.*\/Frameworks\/([^\/]+)\/.*|.*/${1:+ ($1)}/}'
 windowTitle          = '$TM_DISPLAYNAME$windowTitleFramework$windowTitleProject$windowTitleSCM'
+tabTitle             = '$TM_DISPLAYNAME'
 
 excludeDirectoriesInFileChooser  = '{bin/CxxTest,build}'
 excludeDirectoriesInFolderSearch = '{bin/CxxTest,build}'

--- a/Applications/TextMate/resources/Default.tmProperties
+++ b/Applications/TextMate/resources/Default.tmProperties
@@ -9,6 +9,7 @@ binary   = "{*.{ai,bz2,flv,gif,gz,icns,ico,jpg,jpeg,m4v,nib,o,pdf,png,psd,pyc,rt
 windowTitleSCM     = '${TM_SCM_BRANCH:+ ($TM_SCM_NAME: $TM_SCM_BRANCH)}'
 windowTitleProject = '${projectDirectory:+ — ${projectDirectory/^.*\///}}'
 windowTitle        = '$TM_DISPLAYNAME$windowTitleProject$windowTitleSCM'
+tabTitle           = '$TM_DISPLAYNAME'
 
 LANG                 = "en_US.UTF-8"
 LC_CTYPE             = "en_US.UTF-8"

--- a/Frameworks/DocumentWindow/src/DocumentWindowController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentWindowController.mm
@@ -1265,15 +1265,7 @@ static NSArray* const kObservedKeyPaths = @[ @"arrayController.arrangedObjects.p
 {
 	if(self.selectedDocument.displayName)
 	{
-		auto map = self.selectedDocument.variables;
-		auto const& scm = _documentSCMVariables.empty() ? _projectSCMVariables : _documentSCMVariables;
-		map.insert(scm.begin(), scm.end());
-		if(self.projectPath)
-			map["projectDirectory"] = to_s(self.projectPath);
-
-		NSString* docDirectory = self.selectedDocument.path ? [self.selectedDocument.path stringByDeletingLastPathComponent] : self.untitledSavePath;
-		settings_t const settings = settings_for_path(to_s(self.selectedDocument.virtualPath ?: self.selectedDocument.path), to_s(self.selectedDocument.fileType) + " " + to_s(self.scopeAttributes), to_s(docDirectory), map);
-		self.window.title = to_ns(settings.get(kSettingsWindowTitleKey, to_s(self.selectedDocument.displayName)));
+		self.window.title = [self titleForDocument:self.selectedDocument withSetting:kSettingsWindowTitleKey];
 	}
 	else
 	{
@@ -1566,10 +1558,21 @@ static NSArray* const kObservedKeyPaths = @[ @"arrayController.arrangedObjects.p
 // ===========================
 
 - (NSUInteger)numberOfRowsInTabBarView:(OakTabBarView*)aTabBarView                         { return _documents.count; }
-- (NSString*)tabBarView:(OakTabBarView*)aTabBarView titleForIndex:(NSUInteger)anIndex      { return _documents[anIndex].displayName; }
 - (NSString*)tabBarView:(OakTabBarView*)aTabBarView pathForIndex:(NSUInteger)anIndex       { return _documents[anIndex].path ?: @""; }
 - (NSString*)tabBarView:(OakTabBarView*)aTabBarView identifierForIndex:(NSUInteger)anIndex { return _documents[anIndex].identifier.UUIDString; }
 - (BOOL)tabBarView:(OakTabBarView*)aTabBarView isEditedAtIndex:(NSUInteger)anIndex         { return _documents[anIndex].isDocumentEdited; }
+
+- (NSString*)tabBarView:(OakTabBarView*)aTabBarView titleForIndex:(NSUInteger)anIndex
+{
+	if (_documents[anIndex].displayName)
+	{
+		return [self titleForDocument:_documents[anIndex] withSetting:kSettingsTabTitleKey];
+	}
+	else
+	{
+		return _documents[anIndex].displayName;
+	}
+}
 
 // ==============================
 // = OakTabBarView Context Menu =
@@ -2069,6 +2072,19 @@ static NSArray* const kObservedKeyPaths = @[ @"arrayController.arrangedObjects.p
 // ===========
 // = Methods =
 // ===========
+
+- (NSString*)titleForDocument:(OakDocument*)document withSetting:(std::string)setting
+{
+	auto map = document.variables;
+	auto const& scm = _documentSCMVariables.empty() ? _projectSCMVariables : _documentSCMVariables;
+	map.insert(scm.begin(), scm.end());
+	if(self.projectPath) {
+		map["projectDirectory"] = to_s(self.projectPath);
+	}
+	NSString* docDirectory = document.path ? [document.path stringByDeletingLastPathComponent] : self.untitledSavePath;
+	settings_t const settings = settings_for_path(to_s(document.virtualPath ?: document.path), to_s(document.fileType) + " " + to_s(self.scopeAttributes), to_s(docDirectory), map);
+	return to_ns(settings.get(setting, to_s(document.displayName)));
+}
 
 - (NSString*)untitledSavePath
 {

--- a/Frameworks/settings/src/keys.cc
+++ b/Frameworks/settings/src/keys.cc
@@ -22,6 +22,7 @@ std::string const kSettingsInvisiblesMapKey               = "invisiblesMap";
 std::string const kSettingsProjectDirectoryKey            = "projectDirectory";
 std::string const kSettingsSCMStatusKey                   = "scmStatus";
 std::string const kSettingsWindowTitleKey                 = "windowTitle";
+std::string const kSettingsTabTitleKey                 	 = "tabTitle";
 std::string const kSettingsScopeAttributesKey             = "scopeAttributes";
 
 std::string const kSettingsSaveOnBlurKey                  = "saveOnBlur";

--- a/Frameworks/settings/src/keys.h
+++ b/Frameworks/settings/src/keys.h
@@ -25,6 +25,7 @@ PUBLIC extern std::string const kSettingsInvisiblesMapKey;
 PUBLIC extern std::string const kSettingsProjectDirectoryKey;
 PUBLIC extern std::string const kSettingsSCMStatusKey;
 PUBLIC extern std::string const kSettingsWindowTitleKey;
+PUBLIC extern std::string const kSettingsTabTitleKey;
 PUBLIC extern std::string const kSettingsScopeAttributesKey;
 
 PUBLIC extern std::string const kSettingsSaveOnBlurKey;


### PR DESCRIPTION
I updated the OakTabBarViewDataSource tab title method of the DocumentWindowController to use a new setting 'tabTitle' within the .tm_properties file to allow users to change the display name of tabs.

Also moved logic for generating window and tab titles to a new method within the DocumentWindowController called:
(NSString*)titleForDocument:(OakDocument*)document withSetting:(std::string)setting
This was done to remove redundant logic between the window and tab title calls.
Further optimization could be done by storing the docDirectory and settings_t values for each document to avoid generating them twice.