### PR TITLE
Explicitly close OakChoiceMenu

### DIFF
--- a/Frameworks/OakTextView/src/OakChoiceMenu.mm
+++ b/Frameworks/OakTextView/src/OakChoiceMenu.mm
@@ -34,7 +34,8 @@ enum action_t { kActionNop, kActionTab, kActionReturn, kActionCancel, kActionMov
 - (void)dealloc
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	self.window = nil;
+	[_window close];
+	_window = nil;
 }
 
 - (void)sizeToFit


### PR DESCRIPTION
I am on High Sierra and I am noticing that OakChoiceMenu no longer closes unless we explicitly call `close` on the window. I don't know how this will behave on 10.12 or older version. Was there a reason we never called `close` ourselves before?