### PR TITLE
Re-enable building with c++1z

### DIFF
--- a/Frameworks/CommitWindow/src/CommitWindow.mm
+++ b/Frameworks/CommitWindow/src/CommitWindow.mm
@@ -131,7 +131,7 @@ static void* kOakCommitWindowIncludeItemBinding = &kOakCommitWindowIncludeItemBi
 
 		self.clientPortName = someOptions[kOakCommitWindowClientPortName];
 		[self parseArguments:someOptions[kOakCommitWindowArguments]];
-		self.environment = convert(someOptions[kOakCommitWindowEnvironment]);
+		[self setEnvironment:convert(someOptions[kOakCommitWindowEnvironment])];
 
 		// send all diffs to a separate window
 		_environment["TM_PROJECT_UUID"] = to_s(oak::uuid_t().generate());

--- a/Frameworks/document/src/OakDocument.mm
+++ b/Frameworks/document/src/OakDocument.mm
@@ -1567,8 +1567,8 @@ NSString* OakDocumentBookmarkIdentifier           = @"bookmark";
 				{
 					__weak OakDocument* weakSelf = self;
 					_scmInfo->push_callback(^(scm::info_t const& info){
-						weakSelf.scmStatus    = info.status(to_s(weakSelf.path));
-						weakSelf.scmVariables = info.scm_variables();
+						[weakSelf setScmStatus:info.status(to_s(weakSelf.path))];
+						[weakSelf setScmVariables:info.scm_variables()];
 					});
 				}
 			});

--- a/target
+++ b/target
@@ -13,9 +13,9 @@ FLAGS += -fcolor-diagnostics
 FLAGS += -DNDEBUG -Os
 # LINK   = OakDebug
 
-CXX_FLAGS    += -fvisibility=hidden -std=c++14
+CXX_FLAGS    += -fvisibility=hidden -std=c++1z
 OBJC_FLAGS   += -fvisibility=hidden -fobjc-arc -std=c99 -fobjc-abi-version=3
-OBJCXX_FLAGS += -fvisibility=hidden -std=c++14 -fobjc-abi-version=3
+OBJCXX_FLAGS += -fvisibility=hidden -std=c++1z -fobjc-abi-version=3
 OBJCXX_FLAGS += -fobjc-arc -fobjc-call-cxx-cdtors
 LIBS         += c++
 


### PR DESCRIPTION
c++17 now guarantees eliding copys when initializing objects from prvalues. This causes problems when using the GNU extension `?:` operator and when the prvalue is used in method parameters. To force a copy, we cast them to rvalues.

This feels very hacky, but I don't know if there is anything else we can do.