### PR TITLE
allow view plain text files without a file extension in quick look

### DIFF
--- a/Applications/QuickLookGenerator/resources/Info.plist
+++ b/Applications/QuickLookGenerator/resources/Info.plist
@@ -44,6 +44,7 @@
 				<string>public.source-code</string>
 				<string>public.plain-text</string>
 				<string>public.text</string>
+				<string>public.data</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
such as README, LICENCE, makefile etc..