### PR TITLE
Fix generation of contribution page

### DIFF
--- a/Applications/TextMate/about/Contributions.md
+++ b/Applications/TextMate/about/Contributions.md
@@ -8,13 +8,11 @@ See [commits at GitHub][1].
 
 <div>
 <%# this wrapping div prevents Markdown from trying to parse the ERB blocks %>
-
 <%
 last_group_heading = ''
 require File.join(File.dirname(__FILE__), 'bin/gen_credits')
 generate_credits(File.expand_path('~/Library/Caches/com.macromates.TextMate/githubcredits'), warn) do |hash, author, subject, body, userpic, date, github_user|
   group_heading = date.strftime('%b %e, %Y')
-
   if last_group_heading != group_heading
     if last_group_heading != ''
         _erbout << "</ol>\n"
@@ -49,7 +47,6 @@ generate_credits(File.expand_path('~/Library/Caches/com.macromates.TextMate/gith
   </li>
 <%
 end
-
 if last_group_heading != ''
     _erbout << "</ol>\n"
 end


### PR DESCRIPTION
Modern multimarkdown tends to convert the <% and %> tags into HTML when they
occur before or after an empty line. This would then break parsing with erb.
Remove all empty lines in the vicinity of these tags to prevent this problem.

Sent in by @neverpanic through @ryandesign