### PR TITLE
Fix build failure with OS X 10.11 SDK from Xcode 7.0–7.2.1

### DIFF
--- a/Frameworks/DocumentWindow/src/SelectGrammarViewController.mm
+++ b/Frameworks/DocumentWindow/src/SelectGrammarViewController.mm
@@ -21,7 +21,7 @@
 @property (nonatomic) OakDocumentView*     documentView;
 @property (nonatomic) BundleGrammar*       grammar;
 
-@property (nonatomic) void(^callback)(SelectGrammarResponse, BundleGrammar*);
+@property (nonatomic, strong) void(^callback)(SelectGrammarResponse, BundleGrammar*);
 @end
 
 static NSButton* OakSmallButton (NSString* title, SEL action, id target, NSInteger tag)

--- a/Frameworks/OakCommand/src/OakCommand.h
+++ b/Frameworks/OakCommand/src/OakCommand.h
@@ -13,8 +13,8 @@ NS_ENUM(NSInteger) {
 PUBLIC @interface OakCommand : NSObject
 @property (nonatomic, weak) NSResponder* firstResponder;
 @property (nonatomic, readonly) NSUUID* identifier;
-@property (nonatomic) void(^modalEventLoopRunner)(OakCommand*, BOOL* didTerminate);
-@property (nonatomic) void(^terminationHandler)(OakCommand*, BOOL normalExit);
+@property (nonatomic, strong) void(^modalEventLoopRunner)(OakCommand*, BOOL* didTerminate);
+@property (nonatomic, strong) void(^terminationHandler)(OakCommand*, BOOL normalExit);
 @property (nonatomic) BOOL updateHTMLViewAtomically;
 @property (nonatomic, readonly) OakHTMLOutputView* htmlOutputView;
 - (instancetype)initWithBundleCommand:(bundle_command_t const&)aCommand;


### PR DESCRIPTION
Building textmate 2.0-rc.4 on OS X 10.10 with Xcode 7.2.1 (the last version that works on OS X 10.10) with the 10.11 SDK, the build fails:

```
Frameworks/OakCommand/src/OakCommand.mm:182:1: error: ARC forbids synthesizing a property of an Objective-C object with unspecified ownership or storage attribute
@implementation OakCommand
^
Frameworks/OakCommand/src/OakCommand.h:16:29: note: property declared here
@property (nonatomic) void(^modalEventLoopRunner)(OakCommand*, BOOL* didTerminate);
                            ^
Frameworks/OakCommand/src/OakCommand.mm:182:1: error: ARC forbids synthesizing a property of an Objective-C object with unspecified ownership or storage attribute
@implementation OakCommand
^
Frameworks/OakCommand/src/OakCommand.h:17:29: note: property declared here
@property (nonatomic) void(^terminationHandler)(OakCommand*, BOOL normalExit);
                            ^
2 errors generated.
```

```
Frameworks/DocumentWindow/src/SelectGrammarViewController.mm:39:1: error: ARC forbids synthesizing a property of an Objective-C object with unspecified ownership or storage attribute
@implementation SelectGrammarViewController
^
Frameworks/DocumentWindow/src/SelectGrammarViewController.mm:24:29: note: property declared here
@property (nonatomic) void(^callback)(SelectGrammarResponse, BundleGrammar*);
                            ^
1 error generated.
```

From my [brief investigation](https://github.com/AFNetworking/AFNetworking/issues/569), it seems that Xcode 7.3's 10.11 SDK (version 10.11.4) will consider these properties to be `strong` by default, but with Xcode 7.2.1 (10.11 SDK version 10.11.2) and earlier, it has to be specified explicitly.