### PR TITLE
Always uppercase the encoding charset

### DIFF
--- a/Frameworks/file/src/encoding.h
+++ b/Frameworks/file/src/encoding.h
@@ -3,6 +3,7 @@
 
 #include "bytes.h"
 #include <oak/oak.h>
+#include <text/case.h>
 
 PUBLIC extern std::string const kCharsetNoEncoding;
 PUBLIC extern std::string const kCharsetASCII;
@@ -46,7 +47,7 @@ namespace encoding
 		std::string const& charset () const  { return _charset; }
 
 		void set_newlines (std::string const& newlines) { _newlines = newlines; }
-		void set_charset (std::string const& charset)   { _charset = charset; }
+		void set_charset (std::string const& charset)   { _charset = text::uppercase(charset); }
 
 	private:
 		std::string _newlines = NULL_STR;


### PR DESCRIPTION
Apple writes the encoding charset (e.g., com.apple.TextEncoding) in
all lowercase (at least since macOS 10.9); however, TextMate assumes that the
encoding will always be uppercase. So in order to avoid any issues with case
mismatches, when setting the charset, uppercase the given string.

See http://lists.macromates.com/textmate/2018-April/040602.html