### PR TITLE
Switch to TextMate.app when launching from mate

### DIFF
--- a/Applications/mate/src/mate.cc
+++ b/Applications/mate/src/mate.cc
@@ -85,7 +85,7 @@ static void launch_app (bool disableUntitled)
 
 	cf::array_t args(disableUntitled ? std::vector<std::string>{ "-disableNewDocumentAtStartup", "1" } : std::vector<std::string>{ });
 
-	struct LSApplicationParameters const appParams = { 0, kLSLaunchDontAddToRecents|kLSLaunchDontSwitch|kLSLaunchAndDisplayErrors, &appFSRef, nullptr, nullptr, args, nullptr };
+	struct LSApplicationParameters const appParams = { 0, kLSLaunchDontAddToRecents|kLSLaunchAndDisplayErrors, &appFSRef, nullptr, nullptr, args, nullptr };
 	OSStatus err = LSOpenApplication(&appParams, nullptr);
 	if(err != noErr)
 	{


### PR DESCRIPTION
This has been annoying me for a bit as I often have TextMate buried under a bunch of other applications. I've had to `mate` and then command + tab to it before I can start typing. Curious what the motivation was for this originally?