### PR TITLE
Add excludeSCMDeleted to hide deleted files

### DIFF
--- a/Frameworks/OakFileBrowser/src/io/FSDirectoryDataSource.mm
+++ b/Frameworks/OakFileBrowser/src/io/FSDirectoryDataSource.mm
@@ -157,11 +157,10 @@ struct tracking_t : fs::event_callback_t
 	bool allowExpandingLinks = [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsAllowExpandingLinksKey];
 	bool includeHidden       = (dataSource.dataSourceOptions & kFSDataSourceOptionIncludeHidden) == kFSDataSourceOptionIncludeHidden;
 
+	settings_t const settings = settings_for_path(NULL_STR, "", dir);
 	path::glob_list_t globs;
 	if(!includeHidden)
 	{
-		settings_t const& settings = settings_for_path(NULL_STR, "", dir);
-
 		globs.add_exclude_glob(settings.get(kSettingsExcludeDirectoriesInBrowserKey), path::kPathItemDirectory);
 		globs.add_exclude_glob(settings.get(kSettingsExcludeDirectoriesKey),          path::kPathItemDirectory);
 		globs.add_exclude_glob(settings.get(kSettingsExcludeFilesInBrowserKey),       path::kPathItemFile);
@@ -259,7 +258,8 @@ struct tracking_t : fs::event_callback_t
 					pathsOnDisk.insert(fsItem.path);
 				}
 
-				if(scmInfo)
+				// SCM deleted items
+				if(scmInfo && (includeHidden || !settings.get(kSettingsExcludeSCMDeletedKey, false)))
 				{
 					for(auto pair : scmInfo->status())
 					{

--- a/Frameworks/OakFileBrowser/src/io/FSSCMDataSource.mm
+++ b/Frameworks/OakFileBrowser/src/io/FSSCMDataSource.mm
@@ -95,11 +95,11 @@ static NSArray* convert (std::map<std::string, scm::status::type> const& pathsMa
 		std::string root = scm::root_for_path([aPath fileSystemRepresentation]);
 		if(root != NULL_STR)
 				url = [NSURL URLWithString:[NSString stringWithCxxString:"scm://localhost" + encode::url_part(root, "/") + "/"]];
-		else	url = [NSURL URLWithString:[@"scm://locahost" stringByAppendingString:[[aPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] stringByAppendingString:@"?status=unversioned"]]];
+		else	url = [NSURL URLWithString:[@"scm://localhost" stringByAppendingString:[[aPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] stringByAppendingString:@"?status=unversioned"]]];
 	}
 	else
 	{
-		url = [NSURL URLWithString:[@"scm://locahost" stringByAppendingString:[aPath stringByAppendingString:@"?status=disabled"]]];
+		url = [NSURL URLWithString:[@"scm://localhost" stringByAppendingString:[aPath stringByAppendingString:@"?status=disabled"]]];
 	}
 	return url;
 }

--- a/Frameworks/settings/src/keys.cc
+++ b/Frameworks/settings/src/keys.cc
@@ -34,6 +34,7 @@ std::string const kSettingsStoreEncodingPerFileKey        = "storeEncodingPerFil
 std::string const kSettingsDisableExtendedAttributesKey   = "disableExtendedAttributes";
 
 std::string const kSettingsFollowSymbolicLinksKey         = "followSymbolicLinks";
+std::string const kSettingsExcludeSCMDeletedKey           = "excludeSCMDeleted";
 
 std::string const kSettingsIncludeKey                     = "include";
 std::string const kSettingsIncludeDirectoriesKey          = "includeDirectories";

--- a/Frameworks/settings/src/keys.h
+++ b/Frameworks/settings/src/keys.h
@@ -37,6 +37,7 @@ PUBLIC extern std::string const kSettingsStoreEncodingPerFileKey;
 PUBLIC extern std::string const kSettingsDisableExtendedAttributesKey;
 
 PUBLIC extern std::string const kSettingsFollowSymbolicLinksKey;
+PUBLIC extern std::string const kSettingsExcludeSCMDeletedKey;
 
 PUBLIC extern std::string const kSettingsIncludeKey;
 PUBLIC extern std::string const kSettingsIncludeDirectoriesKey;


### PR DESCRIPTION
Add a new setting that prevents deleted files from appearing in the file browser while still uncommitted. There [seems](https://stackoverflow.com/questions/17590302/textmate-2-alpha-showing-references-for-deleted-files) to be some [demand](https://stackoverflow.com/questions/50428259/how-can-i-keep-deleted-files-from-showing-up-in-textmate-2-file-browser-sidebar) for this, and it's just a nice option to have.

Also fixed some apparent typos in FSSCMDataSource.

EDIT: Also, I hereby dedicate this patch to the public domain.