### PR TITLE
Textmate 19 and before....Python output

### DIFF
--- a/Applications/TextMate/about/Changes.md
+++ b/Applications/TextMate/about/Changes.md
@@ -2,6 +2,15 @@ Title: Release Notes
 
 # Changes
 
+Requirement for TextMate will be **10.8** starting with next build.
+
+## 2016-06-22 (v2.0-beta.10)
+
+* The “Add byte order mark” checkbox has been removed from the save panel and so has the `useBOM` setting. Instead byte order mark (BOM) is now part of the encoding name, so via the save panel you need to select “Unicode — UTF-8 (BOM)” to include a BOM or set `encoding = "UTF-8//BOM"` in `.tm_properties`. For UTF-16/32 you also need to append `//BOM` to the encoding name (if you set this via `.tm_properties`).
+* You can change the font used for line numbers by setting `lineNumberFontName` via the `defaults` command. *[Mike Meyer]*
+* More menu changes, most notable the “Go” menu is now “File Browser” and its contents has been revised. The “Go to File…” item (often referred to as ⌘T) is now “File → Quick Open…”. *[Ronald Wampler]*
+* See [all changes since v2.0-beta.9.5](https://github.com/textmate/textmate/compare/v2.0-beta.9.5...v2.0-beta.10)
+
 ## 2016-06-16 (v2.0-beta.9.5)
 
 * Improve folder search performance for large documents with few newlines and lots of matches.

--- a/Applications/TextMate/src/AppController.mm
+++ b/Applications/TextMate/src/AppController.mm
@@ -143,6 +143,9 @@ BOOL HasDocumentWindow (NSArray* windows)
 
 - (void)checkExpirationDate:(id)sender
 {
+	if(oak::os_tuple() < std::make_tuple(10, 8, 0))
+		return;
+
 	NSTimeInterval const kSecondsPerDay = 24*60*60;
 
 	NSDate* currentDate    = [NSDate date];


### PR DESCRIPTION
A simple python file with a print with relative and absolute path does not show the last folder. The one after Boring Stuff/`07-Files`
![captura de pantalla 2018-11-16 a la s 16 12 34](https://user-images.githubusercontent.com/38765698/48642238-fd708a00-e9ba-11e8-9413-701bb3ed28e4.png)

The same result in the terminal.
![captura de pantalla 2018-11-16 a la s 16 13 49](https://user-images.githubusercontent.com/38765698/48642312-4fb1ab00-e9bb-11e8-9aa6-f96aa04ca4e0.png)
