### PR TITLE
Migrate OakTextView to new (10.10+) Accessibility API

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.h
+++ b/Frameworks/OakTextView/src/OakTextView.h
@@ -28,7 +28,7 @@ enum OTVFontSmoothing : NSUInteger
 - (std::map<std::string, std::string>)variables;
 @end
 
-PUBLIC @interface OakTextView : OakView
+PUBLIC @interface OakTextView : OakView <NSAccessibilityNavigableStaticText>
 @property (nonatomic) OakDocument* document;
 
 @property (nonatomic, weak) id <OakTextViewDelegate>        delegate;

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -1424,122 +1424,284 @@ doScroll:
 	[self complete:sender];
 }
 
-// =================
-// = Accessibility =
-// =================
+// =============================
+// = NSAccessibilityStaticText =
+// =============================
 
-- (BOOL)accessibilityIsIgnored
+- (NSAttributedString *)accessibilityAttributedStringForRange:(NSRange)aRange
 {
-	return NO;
-}
+	if(!documentView || !self.theme)
+		return nil;
+	ng::range_t const range = [self rangeForNSRange:aRange];
+	size_t const from = range.min().index, to = range.max().index;
+	std::string const text = documentView->substr(from, to);
+	NSMutableAttributedString* res = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithCxxString:text]];
 
-- (NSSet*)myAccessibilityAttributeNames
-{
-	static NSSet* set = [NSSet setWithArray:@[
-		NSAccessibilityRoleAttribute,
-		NSAccessibilityValueAttribute,
-		NSAccessibilityInsertionPointLineNumberAttribute,
-		NSAccessibilityNumberOfCharactersAttribute,
-		NSAccessibilitySelectedTextAttribute,
-		NSAccessibilitySelectedTextRangeAttribute,
-		NSAccessibilitySelectedTextRangesAttribute,
-		NSAccessibilityVisibleCharacterRangeAttribute,
-		NSAccessibilityChildrenAttribute,
-	]];
-	return set;
-}
+	// Add style
+	std::map<size_t, scope::scope_t> scopes = documentView->scopes(from, to);
+	NSRange runRange = NSMakeRange(0, 0);
+	for(auto pair = scopes.begin(); pair != scopes.end(); )
+	{
+		styles_t const& styles = self.theme->styles_for_scope(pair->second);
 
-- (NSArray*)accessibilityAttributeNames
-{
-	static NSArray* attributes = [[[self myAccessibilityAttributeNames] setByAddingObjectsFromArray:[super accessibilityAttributeNames]] allObjects];
-	return attributes;
-}
+		size_t i = pair->first;
+		size_t j = ++pair != scopes.end() ? pair->first : to - from;
 
-- (id)accessibilityAttributeValue:(NSString*)attribute
-{
-	D(DBF_OakTextView_Accessibility, bug("%s\n", to_s(attribute).c_str()););
-	id ret = nil;
-	if(!documentView)
-		return ret;
+		runRange.location += runRange.length;
+		runRange.length = utf16::distance(text.data() + i, text.data() + j);
+		NSFont* font = (__bridge NSFont *)styles.font();
+		NSMutableDictionary* attributes = [NSMutableDictionary dictionaryWithCapacity:4];
+		[attributes addEntriesFromDictionary:@{
+			NSAccessibilityFontTextAttribute: @{
+				NSAccessibilityFontNameKey: [font fontName],
+				NSAccessibilityFontFamilyKey: [font familyName],
+				NSAccessibilityVisibleNameKey: [font displayName],
+				NSAccessibilityFontSizeKey: @([font pointSize]),
+			},
+			NSAccessibilityForegroundColorTextAttribute: (__bridge id)styles.foreground(),
+			NSAccessibilityBackgroundColorTextAttribute: (__bridge id)styles.background(),
+		}];
+		if(styles.underlined())
+			attributes[NSAccessibilityUnderlineTextAttribute] = @(NSUnderlineStyleSingle | NSUnderlinePatternSolid); // TODO is this always so?
+		if(styles.strikethrough())
+			attributes[NSAccessibilityStrikethroughTextAttribute] = @YES;
 
-	if(false) {
-	} else if([attribute isEqualToString:NSAccessibilityRoleAttribute]) {
-		ret = NSAccessibilityTextAreaRole;
-	} else if([attribute isEqualToString:NSAccessibilityValueAttribute]) {
-		ret = [NSString stringWithCxxString:documentView->substr()];
-	} else if([attribute isEqualToString:NSAccessibilityInsertionPointLineNumberAttribute]) {
-		ret = [NSNumber numberWithUnsignedLong:documentView->softline_for_index(documentView->ranges().last().min())];
-	} else if([attribute isEqualToString:NSAccessibilityNumberOfCharactersAttribute]) {
-		ret = [NSNumber numberWithUnsignedInteger:[self nsRangeForRange:ng::range_t(0, documentView->size())].length];
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextAttribute]) {
-		ng::range_t const selection = documentView->ranges().last();
-		std::string const text = documentView->substr(selection.min().index, selection.max().index);
-		ret = [NSString stringWithCxxString:text];
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextRangeAttribute]) {
-		ret = [NSValue valueWithRange:[self nsRangeForRange:documentView->ranges().last()]];
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextRangesAttribute]) {
-		ng::ranges_t const ranges = documentView->ranges();
-		NSMutableArray* nsRanges = [NSMutableArray arrayWithCapacity:ranges.size()];
-		for(auto const& range : ranges)
-			[nsRanges addObject:[NSValue valueWithRange:[self nsRangeForRange:range]]];
-		ret = nsRanges;
-	} else if([attribute isEqualToString:NSAccessibilityVisibleCharacterRangeAttribute]) {
-		NSRect visibleRect = [self visibleRect];
-		CGPoint startPoint = NSMakePoint(NSMinX(visibleRect), NSMinY(visibleRect));
-		CGPoint   endPoint = NSMakePoint(NSMaxX(visibleRect), NSMaxY(visibleRect));
-		ng::range_t visibleRange(documentView->index_at_point(startPoint), documentView->index_at_point(endPoint));
-		visibleRange = ng::extend(*documentView, visibleRange, kSelectionExtendToEndOfSoftLine).last();
-		return [NSValue valueWithRange:[self nsRangeForRange:visibleRange]];
-	} else if([attribute isEqualToString:NSAccessibilityChildrenAttribute]) {
-		NSMutableArray* links = [NSMutableArray array];
-		std::shared_ptr<links_t> links_ = self.links;
-		for(auto const& pair : *links_)
-			[links addObject:pair.second];
-		return links;
-	} else {
-		ret = [super accessibilityAttributeValue:attribute];
+		[res setAttributes:attributes range:runRange];
 	}
-	return ret;
+
+	// Add links
+	const links_ptr links = self.links;
+	auto lbegin = links->upper_bound(from);
+	auto lend   = links->lower_bound(to);
+	if(lend != links->end() && to >= lend->second.range.min().index)
+		++lend;
+
+	std::for_each(lbegin, lend, [=](links_t::iterator::value_type const& pair){
+		ng::range_t range = pair.second.range;
+		range.first = oak::cap(ng::index_t(from), range.min(), ng::index_t(to));
+		range.last  = oak::cap(ng::index_t(from), range.max(), ng::index_t(to));
+		if(!range.empty())
+		{
+			range.first.index -= from;
+			range.last.index  -= from;
+			NSRange linkRange;
+			linkRange.location = utf16::distance(text.data(), text.data() + range.first.index);
+			linkRange.length   = utf16::distance(text.data() + range.first.index, text.data() + range.last.index);
+			[res addAttribute:NSAccessibilityLinkTextAttribute value:pair.second range:linkRange];
+		}
+	});
+
+	// Add misspellings
+	std::map<size_t, bool> misspellings = documentView->misspellings(from, to);
+	auto pair = misspellings.begin();
+	auto const end = misspellings.end();
+	ASSERT((pair == end) || pair->second);
+	runRange = NSMakeRange(0, 0);
+	if(pair != end)
+		runRange.length = utf16::distance(text.data(), text.data() + pair->first);
+	while(pair != end)
+	{
+		ASSERT(pair != end);
+		ASSERT(pair->second);
+		// assert(runRange.location + runRange.length ~ pair->first)
+		size_t const i = pair->first;
+		size_t const j = (++pair != end) ? pair->first : to - from;
+		ASSERT((pair == end) || (!pair->second));
+		runRange.location += runRange.length;
+		runRange.length = utf16::distance(text.data() + i, text.data() + j);
+
+		[res addAttribute:NSAccessibilityMisspelledTextAttribute value:@(true) range:runRange];
+		[res addAttribute:@"AXMarkedMisspelled" value:@(true) range:runRange];
+
+		if((pair != end) && (++pair != end))
+		{
+			ASSERT(pair->second);
+			size_t const k = pair->first;
+			runRange.location += runRange.length;
+			runRange.length = utf16::distance(text.data() + j, text.data() + k);
+		}
+	}
+
+	// Add text language
+	NSString* lang = [NSString stringWithCxxString:documentView->spelling_language()];
+	[res addAttribute:@"AXNaturalLanguageText" value:lang range:NSMakeRange(0, [res length])];
+
+	return res;
 }
 
-- (BOOL)accessibilityIsAttributeSettable:(NSString*)attribute
+- (NSString*)accessibilityValue
 {
-	static NSArray* settable = @[
-		NSAccessibilityValueAttribute,
-		NSAccessibilitySelectedTextAttribute,
-		NSAccessibilitySelectedTextRangeAttribute,
-		NSAccessibilitySelectedTextRangesAttribute,
-	];
-	if([[self myAccessibilityAttributeNames] containsObject:attribute])
-		return [settable containsObject:attribute];
-	return [super accessibilityIsAttributeSettable:attribute];
+	if(!documentView)
+		return nil;
+	return [NSString stringWithCxxString:documentView->substr()];
 }
 
-- (void)accessibilitySetValue:(id)value forAttribute:(NSString*)attribute
+- (NSRange)accessibilityVisibleCharacterRange
 {
-	D(DBF_OakTextView_Accessibility, bug("%s <- %s\n", to_s(attribute).c_str(), to_s([value description]).c_str()););
+	if(!documentView)
+		return NSMakeRange(0, 0);
+	NSRect visibleRect = [self visibleRect];
+	CGPoint startPoint = NSMakePoint(NSMinX(visibleRect), NSMinY(visibleRect));
+	CGPoint   endPoint = NSMakePoint(NSMaxX(visibleRect), NSMaxY(visibleRect));
+	ng::range_t visibleRange(documentView->index_at_point(startPoint), documentView->index_at_point(endPoint));
+	visibleRange = ng::extend(*documentView, visibleRange, kSelectionExtendToEndOfSoftLine).last();
+	return [self nsRangeForRange:visibleRange];
+}
+
+// ======================================
+// = NSAccessibilityNavigableStaticText =
+// ======================================
+
+- (NSString *)accessibilityStringForRange:(NSRange)nsRange
+{
+	if(!documentView || !self.theme)
+		return nil;
+	ng::range_t range = [self rangeForNSRange:nsRange];
+	return [NSString stringWithCxxString:documentView->substr(range.min().index, range.max().index)];
+}
+
+- (NSInteger)accessibilityLineForIndex:(NSInteger)index
+{
+	if(!documentView || !self.theme)
+		return 0;
+	index = [self rangeForNSRange:NSMakeRange(index, 0)].min().index;
+	size_t line = documentView->softline_for_index(index);
+	return line;
+}
+
+- (NSRange)accessibilityRangeForLine:(NSInteger)lineNumber
+{
+	if(!documentView || !self.theme)
+		return NSMakeRange(0, 0);
+	ng::range_t const range = documentView->range_for_softline(lineNumber);
+	return [self nsRangeForRange:range];
+}
+
+- (NSRect)accessibilityFrameForRange:(NSRange)nsRange
+{
+	if(!documentView || !self.theme)
+		return NSZeroRect;
+	ng::range_t range = [self rangeForNSRange:nsRange];
+	NSRect rect = documentView->rect_for_range(range.min().index, range.max().index, true);
+	rect = [self convertRect:rect toView:nil];
+	return [[self window] convertRectToScreen:rect];
+}
+
+// ===================
+// = NSAccessibility =
+// ===================
+
+- (NSAccessibilityRole)accessibilityRole
+{
+	return NSAccessibilityTextAreaRole;
+}
+
+- (NSInteger)accessibilityInsertionPointLineNumber
+{
+	if(!documentView)
+		return 0;
+	return documentView->softline_for_index(documentView->ranges().last().min());
+}
+
+- (NSInteger)accessibilityNumberOfCharacters
+{
+	if(!documentView)
+		return 0;
+	return [self nsRangeForRange:ng::range_t(0, documentView->size())].length;
+}
+
+- (NSString*)accessibilitySelectedText
+{
+	if(!documentView)
+		return nil;
+	ng::range_t const selection = documentView->ranges().last();
+	std::string const text = documentView->substr(selection.min().index, selection.max().index);
+	return [NSString stringWithCxxString:text];
+}
+
+- (NSRange)accessibilitySelectedTextRange
+{
+	if(!documentView)
+		return NSMakeRange(0, 0);
+	return [self nsRangeForRange:documentView->ranges().last()];
+}
+
+- (NSArray*)accessibilitySelectedTextRanges
+{
+	if(!documentView)
+		return nil;
+	ng::ranges_t const ranges = documentView->ranges();
+	NSMutableArray* nsRanges = [NSMutableArray arrayWithCapacity:ranges.size()];
+	for(auto const& range : ranges)
+		[nsRanges addObject:[NSValue valueWithRange:[self nsRangeForRange:range]]];
+	return nsRanges;
+}
+
+- (NSArray*)accessibilityChildren
+{
+	if(!documentView)
+		return nil;
+	NSMutableArray* links = [NSMutableArray array];
+	std::shared_ptr<links_t> links_ = self.links;
+	for(auto const& pair : *links_)
+		[links addObject:pair.second];
+	return links;
+}
+
+- (void)setAccessibilityValue:(NSString*)value
+{
 	if(!documentView)
 		return;
+	AUTO_REFRESH;
+	_document.content = value;
+}
 
-	if(false) {
-	} else if([attribute isEqualToString:NSAccessibilityValueAttribute]) {
-		AUTO_REFRESH;
-		_document.content = value;
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextAttribute]) {
-		AUTO_REFRESH;
-		documentView->insert(to_s(value));
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextRangeAttribute]) {
-		[self accessibilitySetValue:@[ value ] forAttribute:NSAccessibilitySelectedTextRangesAttribute];
-	} else if([attribute isEqualToString:NSAccessibilitySelectedTextRangesAttribute]) {
-		NSArray* nsRanges = (NSArray*)value;
-		ng::ranges_t ranges;
-		for(NSValue* nsRangeValue in nsRanges)
-			ranges.push_back([self rangeForNSRange:[nsRangeValue rangeValue]]);
-		AUTO_REFRESH;
-		documentView->set_ranges(ranges);
-	} else {
-		[super accessibilitySetValue:value forAttribute:attribute];
-	}
+- (void)setAccessibilitySelectedText:(NSString*)selectedText
+{
+	if(!documentView)
+		return;
+	AUTO_REFRESH;
+	documentView->insert(to_s(selectedText));
+}
+
+- (void)setAccessibilitySelectedTextRange:(NSRange)range
+{
+	if(!documentView)
+		return;
+	[self setAccessibilitySelectedTextRanges:@[ [NSValue valueWithRange:range] ]];
+}
+
+- (void)setAccessibilitySelectedTextRanges:(NSArray*)nsRanges
+{
+	if(!documentView)
+		return;
+	ng::ranges_t ranges;
+	for(NSValue* nsRangeValue in nsRanges)
+		ranges.push_back([self rangeForNSRange:[nsRangeValue rangeValue]]);
+	AUTO_REFRESH;
+	documentView->set_ranges(ranges);
+}
+
+- (NSRange)accessibilityRangeForPosition:(NSPoint)point
+{
+	if(!documentView || !self.theme)
+		return NSMakeRange(0, 0);
+	point = [[self window] convertRectFromScreen:(NSRect){ point, NSZeroSize }].origin;
+	point = [self convertPoint:point fromView:nil];
+	size_t index = documentView->index_at_point(point).index;
+	index = documentView->sanitize_index(index);
+	size_t const length = (*documentView)[index].length();
+	return [self nsRangeForRange:ng::range_t(index, index + length)];
+}
+
+- (NSRange)accessibilityRangeForIndex:(NSInteger)index
+{
+	if(!documentView || !self.theme)
+		return NSMakeRange(0, 0);
+	index = [self rangeForNSRange:NSMakeRange(index, 0)].min().index;
+	index = documentView->sanitize_index(index);
+	size_t const length = (*documentView)[index].length();
+	return [self nsRangeForRange:ng::range_t(index, index + length)];
 }
 
 - (NSUInteger)accessibilityArrayAttributeCount:(NSString* )attribute
@@ -1586,173 +1748,6 @@ doScroll:
 	{
 		return [super accessibilityIndexOfChild:child];
 	}
-}
-
-- (NSArray*)accessibilityParameterizedAttributeNames
-{
-	static NSArray* attributes = nil;
-	if(!attributes)
-	{
-		NSSet* set = [NSSet setWithArray:@[
-			NSAccessibilityLineForIndexParameterizedAttribute,
-			NSAccessibilityRangeForLineParameterizedAttribute,
-			NSAccessibilityStringForRangeParameterizedAttribute,
-			NSAccessibilityRangeForPositionParameterizedAttribute,
-			NSAccessibilityRangeForIndexParameterizedAttribute,
-			NSAccessibilityBoundsForRangeParameterizedAttribute,
-			// NSAccessibilityRTFForRangeParameterizedAttribute,
-			// NSAccessibilityStyleRangeForIndexParameterizedAttribute,
-			NSAccessibilityAttributedStringForRangeParameterizedAttribute,
-		]];
-
-		attributes = [[set setByAddingObjectsFromArray:[super accessibilityParameterizedAttributeNames]] allObjects];
-	}
-	return attributes;
-}
-
-- (id)accessibilityAttributeValue:(NSString*)attribute forParameter:(id)parameter
-{
-	D(DBF_OakTextView_Accessibility, bug("%s(%s)\n", to_s(attribute).c_str(), to_s([parameter description]).c_str()););
-	id ret = nil;
-	if(!documentView || !self.theme)
-		return ret;
-
-	if(false) {
-	} else if([attribute isEqualToString:NSAccessibilityLineForIndexParameterizedAttribute]) {
-		size_t index = [((NSNumber*)parameter) unsignedLongValue];
-		index = [self rangeForNSRange:NSMakeRange(index, 0)].min().index;
-		size_t line = documentView->softline_for_index(index);
-		ret = [NSNumber numberWithUnsignedLong:line];
-	} else if([attribute isEqualToString:NSAccessibilityRangeForLineParameterizedAttribute]) {
-		size_t line = [((NSNumber*)parameter) unsignedLongValue];
-		ng::range_t const range = documentView->range_for_softline(line);
-		ret = [NSValue valueWithRange:[self nsRangeForRange:range]];
-	} else if([attribute isEqualToString:NSAccessibilityStringForRangeParameterizedAttribute]) {
-		ng::range_t range = [self rangeForNSRange:[((NSValue*)parameter) rangeValue]];
-		ret = [NSString stringWithCxxString:documentView->substr(range.min().index, range.max().index)];
-	} else if([attribute isEqualToString:NSAccessibilityRangeForPositionParameterizedAttribute]) {
-		NSPoint point = [((NSValue*)parameter) pointValue];
-		point = [[self window] convertRectFromScreen:(NSRect){ point, NSZeroSize }].origin;
-		point = [self convertPoint:point fromView:nil];
-		size_t index = documentView->index_at_point(point).index;
-		index = documentView->sanitize_index(index);
-		size_t const length = (*documentView)[index].length();
-		ret = [NSValue valueWithRange:[self nsRangeForRange:ng::range_t(index, index + length)]];
-	} else if([attribute isEqualToString:NSAccessibilityRangeForIndexParameterizedAttribute]) {
-		size_t index = [((NSNumber*)parameter) unsignedLongValue];
-		index = [self rangeForNSRange:NSMakeRange(index, 0)].min().index;
-		index = documentView->sanitize_index(index);
-		size_t const length = (*documentView)[index].length();
-		ret = [NSValue valueWithRange:[self nsRangeForRange:ng::range_t(index, index + length)]];
-	} else if([attribute isEqualToString:NSAccessibilityBoundsForRangeParameterizedAttribute]) {
-		ng::range_t range = [self rangeForNSRange:[((NSValue*)parameter) rangeValue]];
-		NSRect rect = documentView->rect_for_range(range.min().index, range.max().index, true);
-		rect = [self convertRect:rect toView:nil];
-		rect = [[self window] convertRectToScreen:rect];
-		ret = [NSValue valueWithRect:rect];
-	// } else if([attribute isEqualToString:NSAccessibilityRTFForRangeParameterizedAttribute]) { // TODO
-	// } else if([attribute isEqualToString:NSAccessibilityStyleRangeForIndexParameterizedAttribute]) { // TODO
-	} else if([attribute isEqualToString:NSAccessibilityAttributedStringForRangeParameterizedAttribute]) {
-		NSRange aRange = [((NSValue *)parameter) rangeValue];
-		ng::range_t const range = [self rangeForNSRange:aRange];
-		size_t const from = range.min().index, to = range.max().index;
-		std::string const text = documentView->substr(from, to);
-		NSMutableAttributedString* res = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithCxxString:text]];
-
-		// Add style
-		std::map<size_t, scope::scope_t> scopes = documentView->scopes(from, to);
-		NSRange runRange = NSMakeRange(0, 0);
-		for(auto pair = scopes.begin(); pair != scopes.end(); )
-		{
-			styles_t const& styles = self.theme->styles_for_scope(pair->second);
-
-			size_t i = pair->first;
-			size_t j = ++pair != scopes.end() ? pair->first : to - from;
-
-			runRange.location += runRange.length;
-			runRange.length = utf16::distance(text.data() + i, text.data() + j);
-			NSFont* font = (__bridge NSFont *)styles.font();
-			NSMutableDictionary* attributes = [NSMutableDictionary dictionaryWithCapacity:4];
-			[attributes addEntriesFromDictionary:@{
-				NSAccessibilityFontTextAttribute: @{
-					NSAccessibilityFontNameKey: [font fontName],
-					NSAccessibilityFontFamilyKey: [font familyName],
-					NSAccessibilityVisibleNameKey: [font displayName],
-					NSAccessibilityFontSizeKey: @([font pointSize]),
-				},
-				NSAccessibilityForegroundColorTextAttribute: (__bridge id)styles.foreground(),
-				NSAccessibilityBackgroundColorTextAttribute: (__bridge id)styles.background(),
-			}];
-			if(styles.underlined())
-				attributes[NSAccessibilityUnderlineTextAttribute] = @(NSUnderlineStyleSingle | NSUnderlinePatternSolid); // TODO is this always so?
-			if(styles.strikethrough())
-				attributes[NSAccessibilityStrikethroughTextAttribute] = @YES;
-
-			[res setAttributes:attributes range:runRange];
-		}
-
-		// Add links
-		const links_ptr links = self.links;
-		auto lbegin = links->upper_bound(from);
-		auto lend   = links->lower_bound(to);
-		if(lend != links->end() && to >= lend->second.range.min().index)
-			++lend;
-
-		std::for_each(lbegin, lend, [=](links_t::iterator::value_type const& pair){
-			ng::range_t range = pair.second.range;
-			range.first = oak::cap(ng::index_t(from), range.min(), ng::index_t(to));
-			range.last  = oak::cap(ng::index_t(from), range.max(), ng::index_t(to));
-			if(!range.empty())
-			{
-				range.first.index -= from;
-				range.last.index  -= from;
-				NSRange linkRange;
-				linkRange.location = utf16::distance(text.data(), text.data() + range.first.index);
-				linkRange.length   = utf16::distance(text.data() + range.first.index, text.data() + range.last.index);
-				[res addAttribute:NSAccessibilityLinkTextAttribute value:pair.second range:linkRange];
-			}
-		});
-
-		// Add misspellings
-		std::map<size_t, bool> misspellings = documentView->misspellings(from, to);
-		auto pair = misspellings.begin();
-		auto const end = misspellings.end();
-		ASSERT((pair == end) || pair->second);
-		runRange = NSMakeRange(0, 0);
-		if(pair != end)
-			runRange.length = utf16::distance(text.data(), text.data() + pair->first);
-		while(pair != end)
-		{
-			ASSERT(pair != end);
-			ASSERT(pair->second);
-			// assert(runRange.location + runRange.length ~ pair->first)
-			size_t const i = pair->first;
-			size_t const j = (++pair != end) ? pair->first : to - from;
-			ASSERT((pair == end) || (!pair->second));
-			runRange.location += runRange.length;
-			runRange.length = utf16::distance(text.data() + i, text.data() + j);
-
-			[res addAttribute:NSAccessibilityMisspelledTextAttribute value:@(true) range:runRange];
-			[res addAttribute:@"AXMarkedMisspelled" value:@(true) range:runRange];
-
-			if((pair != end) && (++pair != end))
-			{
-				ASSERT(pair->second);
-				size_t const k = pair->first;
-				runRange.location += runRange.length;
-				runRange.length = utf16::distance(text.data() + j, text.data() + k);
-			}
-		}
-
-		// Add text language
-		NSString* lang = [NSString stringWithCxxString:documentView->spelling_language()];
-		[res addAttribute:@"AXNaturalLanguageText" value:lang range:NSMakeRange(0, [res length])];
-
-		return res;
-	} else {
-		ret = [super accessibilityAttributeValue:attribute forParameter:parameter];
-	}
-	return ret;
 }
 
 - (id)accessibilityHitTest:(NSPoint)screenPoint

--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -146,9 +146,7 @@ NSString* const kUserDefaultsScrollPastEndKey      = @"scrollPastEnd";
 	} else if([attribute isEqualToString:NSAccessibilityWindowAttribute] || [attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute]) {
 		value = [self.textView accessibilityAttributeValue:attribute];
 	} else if([attribute isEqualToString:NSAccessibilityPositionAttribute] || [attribute isEqualToString:NSAccessibilitySizeAttribute]) {
-		NSRect frame = self.frame;
-		frame = [self.textView convertRect:frame toView:nil];
-		frame = [self.textView.window convertRectToScreen:frame];
+		NSRect frame = NSAccessibilityFrameInView(self.textView, self.frame);
 		if([attribute isEqualToString:NSAccessibilityPositionAttribute])
 			value = [NSValue valueWithPoint:frame.origin];
 		else
@@ -1583,8 +1581,7 @@ doScroll:
 		return NSZeroRect;
 	ng::range_t range = [self rangeForNSRange:nsRange];
 	NSRect rect = documentView->rect_for_range(range.min().index, range.max().index, true);
-	rect = [self convertRect:rect toView:nil];
-	return [[self window] convertRectToScreen:rect];
+	return NSAccessibilityFrameInView(self, rect);
 }
 
 // ===================
@@ -1801,11 +1798,8 @@ doScroll:
 		return;
 
 	size_t const index = documentView->ranges().last().min().index;
-	NSRect selectedRect = documentView->rect_at_index(index, false);
-	selectedRect = [self convertRect:selectedRect toView:nil];
-	selectedRect = [[self window] convertRectToScreen:selectedRect];
-	NSRect viewRect = [self convertRect:[self visibleRect] toView:nil];
-	viewRect = [[self window] convertRectToScreen:viewRect];
+	NSRect selectedRect = NSAccessibilityFrameInView(self, documentView->rect_at_index(index, false));
+	NSRect viewRect = NSAccessibilityFrameInView(self, [self visibleRect]);
 	viewRect.origin.y = [[NSScreen mainScreen] frame].size.height - (viewRect.origin.y + viewRect.size.height);
 	selectedRect.origin.y = [[NSScreen mainScreen] frame].size.height - (selectedRect.origin.y + selectedRect.size.height);
 	UAZoomChangeFocus(&viewRect, &selectedRect, kUAZoomFocusTypeInsertionPoint);


### PR DESCRIPTION
More description in commit messages.

Tested with VoiceOver and Zoom on macOS 10.14.1 (18B75) to make sure it works as expected after the migration.

This makes progress on textmate/bugs#13. For time reasons, I left the `OakAccessibleLink` in OakTextView.mm, as well as accessibility implementations in other files, to be migrated at a later time.

I release the patches in this PR into the public domain.