### PR TITLE
Implement "Symbols" accessibility rotor

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -31,6 +31,7 @@
 #import <layout/layout.h>
 #import <ns/ns.h>
 #import <ns/spellcheck.h>
+#import <text/case.h>
 #import <text/classification.h>
 #import <text/format.h>
 #import <text/newlines.h>
@@ -279,6 +280,12 @@ struct document_view_t : ng::buffer_api_t
 		return buf.symbol_at(ranges().last().first.index);
 	}
 
+	std::map<size_t, std::string> symbols () const
+	{
+		ng::buffer_t const& buf = [_document_editor buffer];
+		return buf.symbols();
+	}
+
 	bool has_marks (std::string const& type = NULL_STR) const
 	{
 		return [_document_editor buffer].prev_mark(SIZE_T_MAX, type).second != NULL_STR;
@@ -460,7 +467,7 @@ private:
 	ng::layout_t* _layout;
 };
 
-@interface OakTextView () <NSTextInputClient, NSDraggingSource, NSIgnoreMisspelledWords, NSChangeSpelling, NSTextFieldDelegate>
+@interface OakTextView () <NSTextInputClient, NSDraggingSource, NSIgnoreMisspelledWords, NSChangeSpelling, NSTextFieldDelegate, NSAccessibilityCustomRotorItemSearchDelegate>
 {
 	OBJC_WATCH_LEAKS(OakTextView);
 
@@ -1700,6 +1707,13 @@ doScroll:
 	return [self nsRangeForRange:ng::range_t(index, index + length)];
 }
 
+- (NSArray*)accessibilityCustomRotors API_AVAILABLE(macos(10.13))
+{
+	return @[
+		[[NSAccessibilityCustomRotor alloc] initWithLabel:@"Symbols" itemSearchDelegate:self],
+	];
+}
+
 - (NSUInteger)accessibilityArrayAttributeCount:(NSString*)attribute
 {
 	if([attribute isEqualToString:NSAccessibilityChildrenAttribute])
@@ -1778,6 +1792,68 @@ doScroll:
 		_links = links;
 	}
 	return _links;
+}
+
+// ================================================
+// = NSAccessibilityCustomRotorItemSearchDelegate =
+// ================================================
+
+- (NSAccessibilityCustomRotorItemResult*)rotor:(NSAccessibilityCustomRotor*)rotor
+                               resultForSearchParameters:(NSAccessibilityCustomRotorSearchParameters*)searchParameters API_AVAILABLE(macos(10.13))
+{
+	auto const symbols = documentView->symbols();
+
+	std::string const filterString = searchParameters.filterString ? text::lowercase(to_s(searchParameters.filterString)) : "";
+
+	auto const substringMatcher = [&filterString](const std::pair<size_t, std::string>& symbolPair){
+		std::string const symbol = text::lowercase(symbolPair.second);
+		return symbol.find(filterString) != std::string::npos;
+	};
+
+	NSAccessibilityCustomRotorItemResult* currentItem = searchParameters.currentItem;
+	NSUInteger const location = currentItem.targetRange.location;
+	auto it = symbols.end();
+
+	switch(searchParameters.searchDirection) {
+		case NSAccessibilityCustomRotorSearchDirectionNext:
+			if (location == NSNotFound) {
+				it = symbols.begin();
+			} else {
+				ng::index_t	const currentIndex = [self rangeForNSRange:NSMakeRange(location, 0)].min();
+				it = symbols.upper_bound(currentIndex.index);
+			}
+			it = std::find_if(it, symbols.end(), substringMatcher);
+			break;
+		case NSAccessibilityCustomRotorSearchDirectionPrevious:
+			if (location == NSNotFound) {
+				it = symbols.end();
+			} else {
+				ng::index_t	const currentIndex = [self rangeForNSRange:NSMakeRange(location, 0)].min();
+				it = symbols.lower_bound(currentIndex.index);
+			}
+			auto rit = std::make_reverse_iterator(it);
+			rit = std::find_if(rit, symbols.rend(), substringMatcher);
+			if (rit == symbols.rend())
+				it = symbols.end();
+			else
+				it = (++rit).base();
+			break;
+	}
+
+	if(it == symbols.end()) {
+		return nil;
+	}
+
+	NSAccessibilityCustomRotorItemResult* result = [[NSAccessibilityCustomRotorItemResult alloc] initWithTargetElement:self];
+
+	ng::index_t const resultIndex = it->first;
+	text::pos_t const pos = documentView->convert(resultIndex.index);
+	size_t const end = documentView->end(pos.line);
+	result.targetRange = [self nsRangeForRange:ng::range_t(resultIndex, end)];
+
+	result.customLabel = [NSString stringWithCxxString:it->second];
+
+	return result;
 }
 
 - (void)updateZoom:(id)sender


### PR DESCRIPTION
Accessibility rotors allow VoiceOver users to navigate content quickly by making possible navigation through select elements only.

In this case, we enable VoiceOver users to navigate efficiently through symbols.

The first way to invoke a rotor is a "global" one (does not take into account current position in text) and is invoked with VO-U. After pressing arrow left/right sufficient times to reach "Symbols", one is presented with a list analogical to the "Jump to symbols" TextMate feature invokable by Shift-Cmd-T. Arrow up and down then enable navigating through items, Return selects the result (and jumps to it), Esc cancels the interface without moving the cursor. Also filtering the list works by simply typing characters (implemented as case-insensitive substring search - consistent e.g. with Safari's "Headings" rotor).

The second way to use a rotor is a "local" one (navigates w.r.t. the current position in text) and is typically done through Trackpad Commander (turned on by VO + two finger "screw" gesture to the right on the Trackpad). Then one uses two-finger "screw" gesture (like (un)screwing the bottle lid from/to the bottle with thumb and index finger) to select "Symbols". When this is finally selected (the selection is persistent), the user can then use flick with one finger up or down gestures to move to the previous/next occurrence respectively.

I made a choice at one spot - I report the "symbol location - end of hardline" as the range of the symbol (that is e.g. what VoiceOver reads when navigating the elements). This seemed to work best for the user at least in the Objective-C code.

The APIs are 10.13+ only, so appropriate avaiability declarations are put in place to not cause warnings from the compiler. I was not surewhether some declaration like that is needed also for the `OakTextView`'s informal category's conformance to the `NSAccessibilityCustomRotorItemSearchDelegate` protocol - the protocol is 10.13+ only too, but the compiler does not warn about conforming to it. Perhaps the Objective-C runtime is smart enough to take into account that the `NSAccessibilityCustomRotorItemSearchDelegate` symbol is (hopefully) weakly-linked and adds conformance to it (I assume using the `class_addProtocol` function) only when it is non-nil. I have however not tested whether the compiled app actually degrades gracefully (without crashing) on macOS 10.12 and earlier, though (for starters, I seem not to have access to a macOS Sierra image to create a VM).

I release the code to the public domain.

## Screenshots

### "Global" rotor for "Symbols"
![screenshot 2018-12-25 at 17 17 49](https://user-images.githubusercontent.com/41975/50424823-590c1e00-086b-11e9-9ecc-5a57934b0ec5.png)

### "Global" rotor for "Symbols" with "blink" filter applied
![screenshot 2018-12-25 at 17 18 29](https://user-images.githubusercontent.com/41975/50424824-5e696880-086b-11e9-9ccc-e528ccd02ab3.png)

### After selecting item in "global" rotor for "Symbols"
![screenshot 2018-12-25 at 17 19 13](https://user-images.githubusercontent.com/41975/50424826-632e1c80-086b-11e9-9cec-93c30fc21f02.png)

### "Local" rotor for "Symbols" offered
![screenshot 2018-12-25 at 17 16 07](https://user-images.githubusercontent.com/41975/50424829-6aedc100-086b-11e9-8acf-438af4220a62.png)