### PR TITLE
Fix the scroll performance of the about window

### DIFF
--- a/Applications/TextMate/about/css/stylesheet.css
+++ b/Applications/TextMate/about/css/stylesheet.css
@@ -18,7 +18,7 @@ body {
 @media screen and (-webkit-min-device-pixel-ratio: 2) {
   body {
     background-image: url("flower@2x.png");
-    background-size: 50%; } }
+    background-size: 363px 359px; } }
 body > h1, body > h2, body > p {
   text-shadow: 0 0 1px var(--backgroundColor), 0 1px 0 var(--shadowColor); }
 


### PR DESCRIPTION
Using background-size: 50% results in really bad scrolling performance and 
doesn't not achieve the effect of scaling the image to double the pixel density,
it rather sets the image width to 50% of the element.

Using the non-retina image size solves both the problems.

A similar issue was found in this SO page: https://stackoverflow.com/a/7034772

_This patch is provided as public domain_