### PR TITLE
Don't push to the parse stack for rules without while or end patterns

### DIFF
--- a/Frameworks/parse/src/parse.cc
+++ b/Frameworks/parse/src/parse.cc
@@ -491,7 +491,7 @@ namespace parse
 					break;
 				}
 			}
-			else if(!rule->children.empty() || rule->while_string != NULL_STR || rule->end_string != NULL_STR) // begin-part of rule
+			else if(rule->while_string != NULL_STR || rule->end_string != NULL_STR) // begin-part of rule
 			{
 				if(m.match.empty() && has_cycle(rule->rule_id, i, stack))
 				{


### PR DESCRIPTION
### Summary

Currently, certain improperly-structured grammar rules can cause TextMate's syntax highlighting engine to perform very deeply-nested recursive calls, making the editor permanently unresponsive when opening large files. These grammar rules do exist in the wild. This PR causes TextMate to ignore the invalid parts of the rules, rather than becoming unresponsive. 

### Background

At GitHub, we use a modified version of TextMate's highlighting engine to perform syntax highlighting on GitHub.com. Recently, we discovered a bug that I believe is still present in TextMate's current engine.

TextMate's [grammar docs](https://macromates.com/manual/en/language_grammars#rule_keys) describe the `patterns` field as something that's only used in rules that *also* have a `begin` and `end` field:

> A begin/end rule can have nested patterns using the patterns key.

Conversely, I believe that it isn't valid for a rule *without* a `begin` and `end` pattern to have `patterns`.

### The Bug

Currently, when it encounters a rule with `patterns` but no `end` (or `while`) pattern, TextMate enters into a bad state: it pushes a node onto its parse stack that can never be popped. TextMate only pops rules from the parse stack in two places:

1. For `while` rules, [here](https://github.com/maxbrunsfeld/textmate/blob/76faa75e9fb0a8db44f503b4aadc493f7dab1163/Frameworks/parse/src/parse.cc#L436) when the pattern stops matching.
2. For `begin`/`end` rules, [here](https://github.com/maxbrunsfeld/textmate/blob/76faa75e9fb0a8db44f503b4aadc493f7dab1163/Frameworks/parse/src/parse.cc#L484) when the `end` pattern matches.

Pushing a stack node without *either* of these fields can cause the parse stack to become deeper and deeper throughout the file and eventually cause the application to become unresponsive indefinitely, with 100% CPU usage.

### Reproduction

1. Add the following Clojure grammar to a TextMate bundle. This is based on that is [used in both Atom](https://github.com/atom/language-clojure/blob/master/grammars/clojure.cson) and [VSCode](https://github.com/microsoft/vscode/blob/master/extensions/clojure/syntaxes/clojure.tmLanguage.json).

<details>
<summary><code>Clojure.tmLanguage</code></summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>comment</key>
  <string>Symbol pattern : [a-zA-Z+!\-_?0-9*~#@'`/.$=]</string>

  <key>version</key>
  <string>https://github.com/atom/language-clojure/commit/de877502aa4a77ccdc2c7f0c9180436aea3effff</string>

   <key>fileTypes</key>
   <array>
        <string>clj</string>
        <string>edn</string>
   </array>

  <key>name</key>
  <string>Clojure</string>

  <key>patterns</key>
  <array>
     <dict>
        <key>include</key>
        <string>#comment</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#shebang-comment</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#quoted-sexp</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#sexp</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#keyfn</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#string</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#vector</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#set</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#map</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#regexp</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#var</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#constants</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#dynamic-variables</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#metadata</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#namespace-symbol</string>
     </dict>
     <dict>
        <key>include</key>
        <string>#symbol</string>
     </dict>
  </array>

  <key>repository</key>
  <dict>
     <key>comment</key>
     <dict>
        <key>begin</key>
        <string>(?&lt;!\\);</string>
        <key>beginCaptures</key>
        <array>
           <dict>
              <key>name</key>
              <string>punctuation.definition.comment.clojure</string>
           </dict>
        </array>
        <key>end</key>
        <string>$</string>
        <key>name</key>
        <string>comment.line.semicolon.clojure</string>
     </dict>
     <key>constants</key>
     <dict>
        <key>patterns</key>
        <array>
           <dict>
              <key>match</key>
              <string>(nil)(?=(\s|\)|\]|\}))</string>
              <key>name</key>
              <string>constant.language.nil.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(true|false)</string>
              <key>name</key>
              <string>constant.language.boolean.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+/\d+)</string>
              <key>name</key>
              <string>constant.numeric.ratio.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+[rR]\w+)</string>
              <key>name</key>
              <string>constant.numeric.arbitrary-radix.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?0[xX][0-9a-fA-F]+)</string>
              <key>name</key>
              <string>constant.numeric.hexadecimal.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?0\d+)</string>
              <key>name</key>
              <string>constant.numeric.octal.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+\.\d+([eE][+-]?\d+)?M)</string>
              <key>name</key>
              <string>constant.numeric.bigdecimal.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+\.\d+([eE][+-]?\d+)?)</string>
              <key>name</key>
              <string>constant.numeric.double.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+N)</string>
              <key>name</key>
              <string>constant.numeric.bigint.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(-?\d+)</string>
              <key>name</key>
              <string>constant.numeric.long.clojure</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#keyword</string>
           </dict>
        </array>
     </dict>
     <key>keyword</key>
     <dict>
        <key>match</key>
        <string>(?&lt;=(\s|\(|\[|\{)):[\w\#\.\-\_\:\+\=\&gt;\&lt;\/\!\?\*]+(?=(\s|\)|\]|\}|\,))</string>
        <key>name</key>
        <string>constant.keyword.clojure</string>
     </dict>
     <key>keyfn</key>
     <dict>
        <key>patterns</key>
        <array>
           <dict>
              <key>match</key>
              <string>(?&lt;=(\s|\(|\[|\{))(if(-[-\p{Ll}\?]*)?|when(-[-\p{Ll}]*)?|for(-[-\p{Ll}]*)?|cond|do|let(-[-\p{Ll}\?]*)?|binding|loop|recur|fn|throw[\p{Ll}\-]*|try|catch|finally|([\p{Ll}]*case))(?=(\s|\)|\]|\}))</string>
              <key>name</key>
              <string>storage.control.clojure</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(?&lt;=(\s|\(|\[|\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def[\p{Ll}\-]*))(?=(\s|\)|\]|\}))</string>
              <key>name</key>
              <string>keyword.control.clojure</string>
           </dict>
        </array>
     </dict>
     <key>dynamic-variables</key>
     <dict>
        <key>match</key>
        <string>\*[\w\.\-\_\:\+\=\&gt;\&lt;\!\?\d]+\*</string>
        <key>name</key>
        <string>meta.symbol.dynamic.clojure</string>
     </dict>
     <key>map</key>
     <dict>
        <key>begin</key>
        <string>(\{)</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.map.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(\}(?=[\}\]\)\s]*(?:;|$)))|(\})</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.map.end.trailing.clojure</string>
           </dict>
           <key>2</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.map.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>meta.map.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>include</key>
              <string>$self</string>
           </dict>
        </array>
     </dict>
     <key>metadata</key>
     <dict>
        <key>patterns</key>
        <array>
           <dict>
              <key>begin</key>
              <string>(\^\{)</string>
              <key>beginCaptures</key>
              <dict>
                 <key>1</key>
                 <dict>
                    <key>name</key>
                    <string>punctuation.section.metadata.map.begin.clojure</string>
                 </dict>
              </dict>
              <key>end</key>
              <string>(\}(?=[\}\]\)\s]*(?:;|$)))|(\})</string>
              <key>endCaptures</key>
              <dict>
                 <key>1</key>
                 <dict>
                    <key>name</key>
                    <string>punctuation.section.metadata.map.end.trailing.clojure</string>
                 </dict>
                 <key>2</key>
                 <dict>
                    <key>name</key>
                    <string>punctuation.section.metadata.map.end.clojure</string>
                 </dict>
              </dict>
              <key>name</key>
              <string>meta.metadata.map.clojure</string>
              <key>patterns</key>
              <array>
                 <dict>
                    <key>include</key>
                    <string>$self</string>
                 </dict>
              </array>
           </dict>
           <dict>
              <key>begin</key>
              <string>(\^)</string>
              <key>end</key>
              <string>(\s)</string>
              <key>name</key>
              <string>meta.metadata.simple.clojure</string>
              <key>patterns</key>
              <array>
                 <dict>
                    <key>include</key>
                    <string>#keyword</string>
                 </dict>
                 <dict>
                    <key>include</key>
                    <string>$self</string>
                 </dict>
              </array>
           </dict>
        </array>
     </dict>
     <key>quoted-sexp</key>
     <dict>
        <key>begin</key>
        <string>(['``]\()</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(\))$|(\)(?=[\}\]\)\s]*(?:;|$)))|(\))</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.trailing.clojure</string>
           </dict>
           <key>2</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.trailing.clojure</string>
           </dict>
           <key>3</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>meta.quoted-expression.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>include</key>
              <string>$self</string>
           </dict>
        </array>
     </dict>
     <key>regexp</key>
     <dict>
        <key>begin</key>
        <string>#"</string>
        <key>beginCaptures</key>
        <array>
           <dict>
              <key>name</key>
              <string>punctuation.definition.regexp.begin.clojure</string>
           </dict>
        </array>
        <key>end</key>
        <string>"</string>
        <key>endCaptures</key>
        <array>
           <dict>
              <key>name</key>
              <string>punctuation.definition.regexp.end.clojure</string>
           </dict>
        </array>
        <key>name</key>
        <string>string.regexp.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>include</key>
              <string>#regexp_escaped_char</string>
           </dict>
        </array>
     </dict>
     <key>regexp_escaped_char</key>
     <dict>
        <key>match</key>
        <string>\\.</string>
        <key>name</key>
        <string>constant.character.escape.clojure</string>
     </dict>
     <key>set</key>
     <dict>
        <key>begin</key>
        <string>(\#\{)</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.set.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(\}(?=[\}\]\)\s]*(?:;|$)))|(\})</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.set.end.trailing.clojure</string>
           </dict>
           <key>2</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.set.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>meta.set.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>include</key>
              <string>$self</string>
           </dict>
        </array>
     </dict>
     <key>sexp</key>
     <dict>
        <key>begin</key>
        <string>(\()</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(\))$|(\)(?=[\}\]\)\s]*(?:;|$)))|(\))</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.trailing.clojure</string>
           </dict>
           <key>2</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.trailing.clojure</string>
           </dict>
           <key>3</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.expression.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>meta.expression.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>begin</key>
              <string>(?&lt;=\()(ns|declare|def[\w\d._:+=&gt;&lt;!?*-]*|[\w._:+=&gt;&lt;!?*-][\w\d._:+=&gt;&lt;!?*-]*/def[\w\d._:+=&gt;&lt;!?*-]*)\s+</string>
              <key>beginCaptures</key>
              <dict>
                 <key>1</key>
                 <dict>
                    <key>name</key>
                    <string>keyword.control.clojure</string>
                 </dict>
              </dict>
              <key>end</key>
              <string>(?=\))</string>
              <key>name</key>
              <string>meta.definition.global.clojure</string>
              <key>patterns</key>
              <array>
                 <dict>
                    <key>include</key>
                    <string>#metadata</string>
                 </dict>
                 <dict>
                    <key>include</key>
                    <string>#dynamic-variables</string>
                 </dict>
                 <dict>
                    <key>match</key>
                    <string>([\p{L}\.\-\_\+\=\&gt;\&lt;\!\?\*][\w\.\-\_\:\+\=\&gt;\&lt;\!\?\*\d]*)</string>
                    <key>name</key>
                    <string>entity.global.clojure</string>
                 </dict>
                 <dict>
                    <key>include</key>
                    <string>$self</string>
                 </dict>
              </array>
           </dict>
           <dict>
              <key>include</key>
              <string>#keyfn</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#constants</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#vector</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#map</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#set</string>
           </dict>
           <dict>
              <key>include</key>
              <string>#sexp</string>
           </dict>
           <dict>
              <key>match</key>
              <string>(?&lt;=\()(.+?)(?=\s|\))</string>
              <key>captures</key>
              <dict>
                 <key>1</key>
                 <dict>
                    <key>name</key>
                    <string>entity.name.function.clojure</string>
                 </dict>
              </dict>
              <key>patterns</key>
              <array>
                 <dict>
                    <key>include</key>
                    <string>$self</string>
                 </dict>
              </array>
           </dict>
           <dict>
              <key>include</key>
              <string>$self</string>
           </dict>
        </array>
     </dict>
     <key>shebang-comment</key>
     <dict>
        <key>begin</key>
        <string>^(#!)</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.definition.comment.shebang.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>$</string>
        <key>name</key>
        <string>comment.line.shebang.clojure</string>
     </dict>
     <key>string</key>
     <dict>
        <key>begin</key>
        <string>(?&lt;!\\)(")</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.definition.string.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(")</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.definition.string.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>string.quoted.double.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>match</key>
              <string>\\.</string>
              <key>name</key>
              <string>constant.character.escape.clojure</string>
           </dict>
        </array>
     </dict>
     <key>namespace-symbol</key>
     <dict>
        <key>patterns</key>
        <array>
           <dict>
              <key>match</key>
              <string>([\p{L}\.\-\_\+\=\&gt;\&lt;\!\?\*][\w\.\-\_\:\+\=\&gt;\&lt;\!\?\*\d]*)/</string>
              <key>captures</key>
              <dict>
                 <key>1</key>
                 <dict>
                    <key>name</key>
                    <string>meta.symbol.namespace.clojure</string>
                 </dict>
              </dict>
           </dict>
        </array>
     </dict>
     <key>symbol</key>
     <dict>
        <key>patterns</key>
        <array>
           <dict>
              <key>match</key>
              <string>([\p{L}\.\-\_\+\=\&gt;\&lt;\!\?\*][\w\.\-\_\:\+\=\&gt;\&lt;\!\?\*\d]*)</string>
              <key>name</key>
              <string>meta.symbol.clojure</string>
           </dict>
        </array>
     </dict>
     <key>var</key>
     <dict>
        <key>match</key>
        <string>(?&lt;=(\s|\(|\[|\{)\#)'[\w\.\-\_\:\+\=\&gt;\&lt;\/\!\?\*]+(?=(\s|\)|\]|\}))</string>
        <key>name</key>
        <string>meta.var.clojure</string>
     </dict>
     <key>vector</key>
     <dict>
        <key>begin</key>
        <string>(\[)</string>
        <key>beginCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.vector.begin.clojure</string>
           </dict>
        </dict>
        <key>end</key>
        <string>(\](?=[\}\]\)\s]*(?:;|$)))|(\])</string>
        <key>endCaptures</key>
        <dict>
           <key>1</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.vector.end.trailing.clojure</string>
           </dict>
           <key>2</key>
           <dict>
              <key>name</key>
              <string>punctuation.section.vector.end.clojure</string>
           </dict>
        </dict>
        <key>name</key>
        <string>meta.vector.clojure</string>
        <key>patterns</key>
        <array>
           <dict>
              <key>include</key>
              <string>$self</string>
           </dict>
        </array>
     </dict>
  </dict>

  <key>scopeName</key>
  <string>source.clojure</string>
  <key>uuid</key>
  <string>6A87759F-F746-4E84-B788-965B46363202</string>
</dict>
</plist>
```
</details>

2. Open [this `.edn` file](https://gist.github.com/rogerallen/84d006ac2021743e688796511a24dcaf#file-1_archive-edn) in TextMate.

3. Notice that TextMate's CPU usage remains at 100% indefinitely. A CPU profile shows a recursive call to `scope_t::to_s_helper` that's hundreds of frames deep:

<img width="809" alt="Screen Shot 2019-08-26 at 3 45 37 PM" src="https://user-images.githubusercontent.com/326587/63729155-388dcc80-c81b-11e9-8ef2-ea616e9cc076.png">

### The Fix

There was an explicit condition that allowed pushing stack nodes *without* a `while` or an `end`, as long as they had `children` (`patterns`). I have simply removed that condition. I believe the push and pop operations should be balanced, and `patterns` is not intended to be supported without an `end` (or `while`).

### Questions

I'm not very familiar with TextMate, so I may be missing something. Is this a reasonable fix? If someone has more of an understanding of *why* that condition was there, I would be curious to the background.