### PR TITLE
Check for the “libplist” conflicting headers

### DIFF
--- a/configure
+++ b/configure
@@ -82,6 +82,16 @@ for dep in ninja ragel multimarkdown pgrep pkill; do
 	which -s "$dep" || error "*** dependency missing: ‘${dep}’."
 done
 
+for libplistdir in /usr/include/plist /{opt,usr}/local/include/plist ; do
+    if [[ -d $libplistdir ]]; then
+        if which -s brew && brew ls --versions libplist > /dev/null; then
+            error "*** conflict found: ‘libplist’ at: ${libplistdir}. Use \`brew unlink libplist\` before building."
+        else
+            error "*** conflict found: ‘libplist’ at: ${libplistdir}. Remove or unlink this directory before building."
+        fi
+    fi
+done
+
 # =====================================
 # = Generate fixtures and build files =
 # =====================================


### PR DESCRIPTION
The headers for the `libplist` open-source library† conflict with those within TextMate’s “plist” framework – specifically it has a `<plist/plist.h>` header, as well as a `<plist/Date.h>` header which will be picked up by TextMate’s build system and only generate a compiler warning instead of a hard error.

The “hard errors” come afterwards, and without explanations‡ – I have been trying to get TextMate to build for four days now without understanding why it was failing mysteriously on multitudinous files _including_ `<plist/plist.h>` while compiling `Frameworks/src/plist/plist.cc` wasn’t an issue.

This shell snippet, included in `./configure` under the “Check various dependencies” aegis, detects the `libplist` header directories, errors out if they are present, and (depending on whether or not Homebrew is available) offers a bit of terse advice about how to proceed.

![Screen Shot 2020-02-16 at 9 55 03 AM](https://user-images.githubusercontent.com/378969/74607050-5a1d9180-50a3-11ea-967b-97f78cce163b.jpg)

† _Figure 1:_ `libplist` _header layout._

![Screen Shot 2020-02-16 at 9 55 24 AM](https://user-images.githubusercontent.com/378969/74607067-71f51580-50a3-11ea-9b4d-431763d859ba.jpg)

‡ _Figure 2: examples of errors resulting from the conflicting headers._