### PR TITLE
Pass `trim_mode` by keyword in `ERB#initialize`

### DIFF
--- a/bin/gen_test
+++ b/bin/gen_test
@@ -30,7 +30,7 @@ ARGV.each do |file|
   end
 end
 
-STDOUT << ERB.new(DATA.read, 0, '-<>').result(binding)
+STDOUT << ERB.new(DATA.read, trim_mode: '-<>').result(binding)
 
 __END__
 #line 37 "<%= $PROGRAM_NAME %>"


### PR DESCRIPTION
Running `bin/gen_test` spews a titanic quantity of Ruby depreciation warnings for this one call to `ERB#initialize`. The call is using a pair of obsolete positional parameters and the new calling convention has been available since MRI Ruby 2.6. 

Q.v. https://bugs.ruby-lang.org/issues/14256 supra. for the issue and the resolution. This PR makes the update as indicated therein, silencing the waves of warnings.