### PR TITLE
Miscapitalization of Menu Items

### DIFF
--- a/Applications/TextMate/src/AppController.mm
+++ b/Applications/TextMate/src/AppController.mm
@@ -311,8 +311,8 @@ BOOL HasDocumentWindow (NSArray* windows)
 				{ @"Jump to Previous Bookmark",  @selector(goToPreviousBookmark:),         .key = NSF2FunctionKey, .modifierFlags = NSEventModifierFlagShift },
 				{ @"Jump to Bookmark",           .delegate = OakSubmenuController.sharedInstance },
 				{ /* -------- */ },
-				{ @"Jump To Next Mark",          @selector(jumpToNextMark:),               .key = NSF3FunctionKey, .modifierFlags = 0 },
-				{ @"Jump To Previous Mark",      @selector(jumpToPreviousMark:),           .key = NSF3FunctionKey, .modifierFlags = NSEventModifierFlagShift },
+				{ @"Jump to Next Mark",          @selector(jumpToNextMark:),               .key = NSF3FunctionKey, .modifierFlags = 0 },
+				{ @"Jump to Previous Mark",      @selector(jumpToPreviousMark:),           .key = NSF3FunctionKey, .modifierFlags = NSEventModifierFlagShift },
 				{ /* -------- */ },
 				{ @"Scroll",
 					.submenu = {


### PR DESCRIPTION
The preposition `to` in `Jump to Next/Previous Mark` should be capitalized as in `Jump to Next/Previous Bookmark`. Prepositions are generally not capitalized in title case.
