### PR TITLE
Fix Previous/Next Bookmark action in OakTextView touch bar

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView.mm
+++ b/Frameworks/OakTextView/src/OakTextView.mm
@@ -3001,7 +3001,7 @@ static NSTouchBarItemIdentifier kOTVTouchBarItemIdentifierAddRemoveBookmark  = @
 		NSSegmentedControl* navigateMarkerSegmentedControl = [NSSegmentedControl new];
 		navigateMarkerSegmentedControl.segmentCount = 2;
 		navigateMarkerSegmentedControl.target       = self;
-		navigateMarkerSegmentedControl.action       = @selector(performNavigateBookMarksSegmentAction:);
+		navigateMarkerSegmentedControl.action       = @selector(performNavigateBookmarksSegmentAction:);
 		navigateMarkerSegmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
 		navigateMarkerSegmentedControl.segmentStyle = NSSegmentStyleSeparated;
 


### PR DESCRIPTION
performNavigateBookMarksSegmentAction → performNavigateBookmarksSegmentAction

Sadly, this was broken since 4820e876d2fdcab10c8759645f04ed5f6f20e007.