### PR TITLE
Search and replace text fields changed to use NSComboBox

### DIFF
--- a/Frameworks/Find/src/FFTextFieldViewController.h
+++ b/Frameworks/Find/src/FFTextFieldViewController.h
@@ -6,6 +6,4 @@
 @property (nonatomic) NSString* stringValue;
 
 - (instancetype)initWithPasteboard:(OakPasteboard*)pasteboard grammarName:(NSString*)grammarName;
-- (void)showHistory:(id)sender;
-- (void)showPopoverWithString:(NSString*)aString;
 @end


### PR DESCRIPTION
Search and replace text fields changed to use the NSComboBox class. I've removed all references to the popover and the history buttons previously used but I've kept the OakPasteboardSelector class and the helper methods in OakPasteboard, I can delete them after discussion on another commit.