### PR TITLE
Set the frame size via NSTitlebarAccessoryViewController's view property

### DIFF
--- a/Frameworks/OakAppKit/src/OakPasteboardChooser.mm
+++ b/Frameworks/OakAppKit/src/OakPasteboardChooser.mm
@@ -226,10 +226,10 @@ static NSMutableDictionary* SharedChoosers;
 - (void)addTitlebarAccessoryView:(NSView*)titlebarView
 {
 	titlebarView.translatesAutoresizingMaskIntoConstraints = NO;
-	[titlebarView setFrameSize:titlebarView.fittingSize];
 
 	_accessoryViewController = [[NSTitlebarAccessoryViewController alloc] init];
 	_accessoryViewController.view = titlebarView;
+	[_accessoryViewController.view setFrameSize:titlebarView.fittingSize];
 	[self.window addTitlebarAccessoryViewController:_accessoryViewController];
 }
 

--- a/Frameworks/OakFilterList/src/OakChooser.mm
+++ b/Frameworks/OakFilterList/src/OakChooser.mm
@@ -162,10 +162,10 @@ static void* kFirstResponderBinding = &kFirstResponderBinding;
 - (void)addTitlebarAccessoryView:(NSView*)titlebarView
 {
 	titlebarView.translatesAutoresizingMaskIntoConstraints = NO;
-	[titlebarView setFrameSize:titlebarView.fittingSize];
 
 	_accessoryViewController = [[NSTitlebarAccessoryViewController alloc] init];
 	_accessoryViewController.view = titlebarView;
+	[_accessoryViewController.view setFrameSize:titlebarView.fittingSize];
 	[self.window addTitlebarAccessoryViewController:_accessoryViewController];
 }
 


### PR DESCRIPTION
When linking against the macOS 11.0 SDK, the view size fails to update.