### PR TITLE
Prevent UTTypeConformsTo self-reference

### DIFF
--- a/Applications/TextMate/resources/Info.plist
+++ b/Applications/TextMate/resources/Info.plist
@@ -2937,7 +2937,7 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>public.shell-script</string>
+				<string>public.script</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Shell script</string>


### PR DESCRIPTION
Prevent public.shell-script from conforming to itself creating a loop, should conform to public.script.

Reported by Thomas Tempelmann.