### PR TITLE
Set Preference window toolbar style to NSWindowToolbarStylePreference…

### DIFF
--- a/Frameworks/Preferences/src/Preferences.mm
+++ b/Frameworks/Preferences/src/Preferences.mm
@@ -117,6 +117,10 @@ static NSString* const kMASPreferencesSelectedViewKey = @"MASPreferences Selecte
 		window.delegate           = self;
 		window.hidesOnDeactivate  = NO;
 		window.toolbar            = toolbar;
+		if(@available(macos 11.0, *))
+		{
+			window.toolbarStyle = NSWindowToolbarStylePreference;
+		}
 	}
 	return self;
 }


### PR DESCRIPTION
… for Big Sur

Before:
![Screen Shot 2021-01-16 at 5 01 18 PM](https://user-images.githubusercontent.com/1371296/104824024-8b0ac700-581c-11eb-9724-49570ef1a216.png)

After:
![Screen Shot 2021-01-16 at 5 00 25 PM](https://user-images.githubusercontent.com/1371296/104824032-93630200-581c-11eb-8f4c-7031192b6907.png)


To completely match the new preference toolbar style for Big Sur, the icons should be switched to use SF Symbols. I think we can replace all of the icons with the exception of "Bundles" with the current set of SF Symbols provided by Apple. 