### PR TITLE
Fix `toggleing` typo in Preferences pane

### DIFF
--- a/Frameworks/Preferences/src/ProjectsPreferences.mm
+++ b/Frameworks/Preferences/src/ProjectsPreferences.mm
@@ -127,7 +127,7 @@
 	NSButton* keepCurrentDocumentSelectedCheckBox      = OakCreateCheckBox(@"Keep current document selected");
 
 	NSPopUpButton* fileBrowserPositionPopUp            = OakCreatePopUpButton();
-	NSButton* adjustWindowWhenToggleingDisplayCheckBox = OakCreateCheckBox(@"Adjust window when toggleing display");
+	NSButton* adjustWindowWhenTogglingDisplayCheckBox = OakCreateCheckBox(@"Adjust window when toggling display");
 
 	NSButton* showForSingleDocumentCheckBox            = OakCreateCheckBox(@"Show for single document");
 	NSButton* reOrderWhenOpeningAFileCheckBox          = OakCreateCheckBox(@"Re-order when opening a file");
@@ -160,7 +160,7 @@
 		@[ NSGridCell.emptyContentView,                keepCurrentDocumentSelectedCheckBox      ],
 		@[ ],
 		@[ OakCreateLabel(@"Show file browser on:"),   fileBrowserPositionPopUp                 ],
-		@[ NSGridCell.emptyContentView,                adjustWindowWhenToggleingDisplayCheckBox ],
+		@[ NSGridCell.emptyContentView,                adjustWindowWhenTogglingDisplayCheckBox  ],
 		@[ ],
 		@[ OakCreateLabel(@"Document tabs:"),          showForSingleDocumentCheckBox            ],
 		@[ NSGridCell.emptyContentView,                reOrderWhenOpeningAFileCheckBox          ],
@@ -190,7 +190,7 @@
 	[openFilesOnSingleClickCheckBox           bind:NSValueBinding       toObject:self withKeyPath:@"fileBrowserSingleClickToOpen" options:nil];
 	[keepCurrentDocumentSelectedCheckBox      bind:NSValueBinding       toObject:self withKeyPath:@"autoRevealFile"               options:nil];
 	[fileBrowserPositionPopUp                 bind:NSSelectedTagBinding toObject:self withKeyPath:@"fileBrowserPlacement"         options:@{ NSValueTransformerNameBindingOption: @"OakFileBrowserPlacementSettingsTransformer" }];
-	[adjustWindowWhenToggleingDisplayCheckBox bind:NSValueBinding       toObject:self withKeyPath:@"disableAutoResize"            options:@{ NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName }];
+	[adjustWindowWhenTogglingDisplayCheckBox  bind:NSValueBinding       toObject:self withKeyPath:@"disableAutoResize"            options:@{ NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName }];
 	[showForSingleDocumentCheckBox            bind:NSValueBinding       toObject:self withKeyPath:@"disableTabBarCollapsing"      options:nil];
 	[reOrderWhenOpeningAFileCheckBox          bind:NSValueBinding       toObject:self withKeyPath:@"disableTabReordering"         options:@{ NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName }];
 	[automaticallyCloseUnusedTabsCheckBox     bind:NSValueBinding       toObject:self withKeyPath:@"disableTabAutoClose"          options:@{ NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName }];


### PR DESCRIPTION
- Fixes the typo in the `Preferences → Projects` pane.

![preferences_typo](https://user-images.githubusercontent.com/5652327/155441500-6014049e-9c03-4e5c-be7d-3ed06dbfcea7.jpg)

