### PR TITLE
Avoid clang 15 crash by using correct array size

### DIFF
--- a/Frameworks/Find/src/Find.mm
+++ b/Frameworks/Find/src/Find.mm
@@ -1017,7 +1017,7 @@ static NSButton* OakCreateHistoryButton (NSString* toolTip)
 
 - (void)didFind:(NSUInteger)aNumber occurrencesOf:(NSString*)aFindString atPosition:(text::pos_t const&)aPosition wrapped:(BOOL)didWrap
 {
-	static std::string const formatStrings[4][3] = {
+	static std::string const formatStrings[2][3] = {
 		{ "No more occurrences of “${found}”.", "Found “${found}”${line:+ at line ${line}, column ${column}}.",               "${count} occurrences of “${found}”." },
 		{ "No more matches for “${found}”.",    "Found one match for “${found}”${line:+ at line ${line}, column ${column}}.", "${count} matches for “${found}”."    },
 	};


### PR DESCRIPTION
Clang 15 crashes when compiling this code because the size of the array does not match the initializer. This is fixed in clang 16, but `Apple clang version 14.0.3 (clang-1403.0.22.14.1)` which is currently shipped in Ventura is still affected by this.

See https://github.com/llvm/llvm-project/issues/56016 for the upstream report of this problem.