### PR TITLE
Fix Regex Handling to Prevent XSS Injection

### DIFF
--- a/Frameworks/HTMLOutput/resources/error_not_found.html
+++ b/Frameworks/HTMLOutput/resources/error_not_found.html
@@ -12,7 +12,7 @@
 <p>The requested file was not found: <code><script>
   var path = /[&?]path=([^&]+)/.exec(window.location.search)[1];
   path = unescape(unescape(path));
-  path = path.replace(/&/, "&amp;").replace(/</, "&lt;");
+  path = path.replace(/&/gm, "&amp;").replace(/</gm, "&lt;");
   document.write(path);
 </script></code></p>
 


### PR DESCRIPTION
This PR aims to resolve the possibility of XSS injection via the use of payloads like `<<img%20src%3Dx%20onerror%3Dalert%28"XSS"%29>` by adding the RegExp modifier `/gm` (Global Multiline)