### PR TITLE
Fix incorrect number of seconds in a day in regexp (60 * 60 * 24 = 86400, not 84600)

### DIFF
--- a/Frameworks/regexp/src/format_string.cc
+++ b/Frameworks/regexp/src/format_string.cc
@@ -217,7 +217,7 @@ struct expand_visitor : boost::static_visitor<void>
 				else if(duration < 90)       asprintf(&tmp, "a minute ago");
 				else if(duration < 3570)     asprintf(&tmp, "%.0f minutes ago", duration/60);
 				else if(duration < 5400)     asprintf(&tmp, "an hour ago");
-				else if(duration < 84600)    asprintf(&tmp, "%.0f hours ago", duration/(60*60));
+				else if(duration < 86400)    asprintf(&tmp, "%.0f hours ago", duration/(60*60));
 				else if(duration < 129600)   asprintf(&tmp, "a day ago");
 				else if(duration < 561600)   asprintf(&tmp, "%.0f days ago", duration/(24*60*60));
 				else if(duration < 1036800)  asprintf(&tmp, "a week ago");


### PR DESCRIPTION
Fixes the "hours ago" format string.