### PR TITLE
Add attr.filebrowser scope

### DIFF
--- a/Frameworks/DocumentWindow/src/DocumentWindowController.mm
+++ b/Frameworks/DocumentWindow/src/DocumentWindowController.mm
@@ -1483,6 +1483,15 @@ static NSArray* const kObservedKeyPaths = @[ @"arrayController.arrangedObjects.p
 	attributes.insert(_projectScopeAttributes.begin(), _projectScopeAttributes.end());
 	attributes.insert(_externalScopeAttributes.begin(), _externalScopeAttributes.end());
 
+	if (self.fileBrowserVisible) {
+		NSResponder *first = [self.window firstResponder];
+		if ([first isKindOfClass:[NSView class]] &&
+			[(NSView *)first isDescendantOf:self.fileBrowser.view])
+		{
+			attributes.insert("attr.filebrowser");
+		}
+	}
+
 	return [NSString stringWithCxxString:text::join(attributes, " ")];
 }
 


### PR DESCRIPTION
**Description**
This PR extends scope by adding a new attribute, `attr.filebrowser`, whenever the file browser pane has keyboard focus.

This enables bundle commands whose scope selector includes to run only when the user is (not) actively focused in the file browser.
